### PR TITLE
Add support for referencing current parition

### DIFF
--- a/lib/generator/index.ts
+++ b/lib/generator/index.ts
@@ -410,8 +410,8 @@ export function createModule(module: Module): Promise<void> {
       const paramName = lowerFirst(camelCase(param));
       let orDefault = '';
       if (param == 'Partition') {
-        orDefault = " || 'aws'";
-        paramDocs += `\n@param ${paramName} - Partition of the AWS account [aws, aws-cn, aws-us-gov]; defaults to \`aws\`.`;
+        orDefault = ` || ${classDeclaration.getName()}.defaultPartition`;
+        paramDocs += `\n@param ${paramName} - Partition of the AWS account [aws, aws-cn, aws-us-gov]; defaults to \`aws\`, unless using the CDK, where the default is the current Stack's partition.`;
       } else if (param == 'Region') {
         orDefault = " || '*'";
         paramDocs += `\n@param ${paramName} - Region of the resource; defaults to empty string: all regions.`;

--- a/lib/shared/policy-statement/1-base.CDK.ts
+++ b/lib/shared/policy-statement/1-base.CDK.ts
@@ -1,11 +1,18 @@
 // This file is used in the CDK variant of the package: cdk-iam-floyd
 // @ts-ignore only available running bin/mkcdk
-import { aws_iam as iam } from 'aws-cdk-lib';
+import { Aws, aws_iam as iam } from 'aws-cdk-lib';
 
 /**
  * Base class for the Policy Statement
  */
 export class PolicyStatementBase extends iam.PolicyStatement {
+
+  /**
+   * The default partition for ARNs (such as one of [aws, aws-us-gov, aws-cn]). In
+   * CDK applications, this is a reference to the current parition, otherwise, 'aws'.
+   */
+  protected static readonly defaultPartition = Aws.PARTITION;
+
   /**
    * Holds the prefix of the service actions, e.g. `ec2`
    */

--- a/lib/shared/policy-statement/1-base.ts
+++ b/lib/shared/policy-statement/1-base.ts
@@ -4,6 +4,12 @@
  * Base class for the Policy Statement
  */
 export class PolicyStatementBase {
+  /**
+   * The default partition for ARNs (such as one of [aws, aws-us-gov, aws-cn]). In
+   * CDK applications, this is a reference to the current parition, otherwise, 'aws'.
+   */
+  protected static readonly defaultPartition = 'aws';
+
   public sid = '';
 
   /**


### PR DESCRIPTION
This makes it possible to reference the current partition from within a CDK stack (using Aws.PARTITION). This is accomplished by adding a `defaultPartition` attribute to the PolicyStatementBase class. In the CDK this is the `Aws.PARTITION` variable, otherwise, it retains the current default of `'aws'`.

Making `defaultPartition` an instance variable seemed odd, so it's instead a `protected static` member. I'm also not sure if there's a great way to detect whether the generation is for the CDK and I wasn't sure of an elegant way to modify that one line of the JSDoc within `mkcdk.ts`.

Finally, I wasn't exactly sure how to test this. I ran `make generate` and `make cdk-all`; however, there was a CDK build failure both on this branch and on the `main` branch around the `'@aws-cdk/core:enableStackNameDuplicates'` feature flag.

Implements #127 