### PR TITLE
Support autodetecting partition in `forXXX`

### DIFF
--- a/lib/shared/policy-statement/6-principals.ts
+++ b/lib/shared/policy-statement/6-principals.ts
@@ -98,7 +98,7 @@ export class PolicyStatementWithPrincipal extends PolicyStatementWithEffect {
    */
   public forAccount(...accounts: string[]) {
     accounts.forEach((account) =>
-      this.addPrincipal(PrincipalType.AWS, `arn:aws:iam::${account}:root`)
+      this.addPrincipal(PrincipalType.AWS, `arn:${PolicyStatementWithPrincipal.defaultPartition}:iam::${account}:root`)
     );
     return this;
   }
@@ -166,7 +166,7 @@ export class PolicyStatementWithPrincipal extends PolicyStatementWithEffect {
    */
   public forSaml(account: string, ...providerNames: string[]) {
     providerNames.forEach((providerName) =>
-      this.forFederated(`arn:aws:iam::${account}:saml-provider/${providerName}`)
+      this.forFederated(`arn:${PolicyStatementWithPrincipal.defaultPartition}:iam::${account}:saml-provider/${providerName}`)
     );
     return this;
   }
@@ -181,7 +181,7 @@ export class PolicyStatementWithPrincipal extends PolicyStatementWithEffect {
     users.forEach((user) =>
       this.addPrincipal(
         PrincipalType.AWS,
-        `arn:aws:iam::${account}:user/${user}`
+        `arn:${PolicyStatementWithPrincipal.defaultPartition}:iam::${account}:user/${user}`
       )
     );
     return this;
@@ -197,7 +197,7 @@ export class PolicyStatementWithPrincipal extends PolicyStatementWithEffect {
     roles.forEach((role) =>
       this.addPrincipal(
         PrincipalType.AWS,
-        `arn:aws:iam::${account}:role/${role}`
+        `arn:${PolicyStatementWithPrincipal.defaultPartition}:iam::${account}:role/${role}`
       )
     );
     return this;
@@ -218,7 +218,7 @@ export class PolicyStatementWithPrincipal extends PolicyStatementWithEffect {
     sessionNames.forEach((sessionName) => {
       this.addPrincipal(
         PrincipalType.AWS,
-        `arn:aws:sts::${account}:assumed-role/${roleName}/${sessionName}`
+        `arn:${PolicyStatementWithPrincipal.defaultPartition}:sts::${account}:assumed-role/${roleName}/${sessionName}`
       );
     });
     return this;


### PR DESCRIPTION
This expands a bit on the partition support added in #129. It helps CDK
users who need to do `forAccount("123456789012")` so that the partition
in the ARN is correct; however, it doesn't provide a more general
solution since `defaultPartition` is still hardcoded to `"aws"` for the
standard version of the library.

Because the `forXXX` methods accept a variable-length argument in the
last position, adding a `partition?: string` parameter would require
placing it before that argument, becoming an API-breaking change for a
rarer use-case.

A workaround is to use the `for()` in non-standard partitions and to
supply the ARN directly. But this will make it at least a little easier
for `cdk-iam-floyd` users (though, they have `forCdkPrincipal` so maybe
it doesn't help a ton).

Sorry for not including this in the original PR, I actually just noticed
it today when try to apply a policy to API Gateway :) I did a
`git grep "arn:aws:"` and didn't find anything else outside of
docs/tests/examples.