### PR TITLE
restore compatibility with CDK 2.26.0

### DIFF
--- a/CHANGELOG/v0.377.0.md
+++ b/CHANGELOG/v0.377.0.md
@@ -1,3 +1,15 @@
+# :warning: BREAKING CHANGES
+
+To restore compatibility with CDK [2.26.0](https://github.com/aws/aws-cdk/compare/v2.25.0...v2.26.0#diff-0ae3b84aa2e09276610b62695ce2b3485fde733b8ae0708053e6a075e17c6c11) some methods had to be renamed:
+
+notAction**s** -> notAction<br>
+notResource**s** -> notResource<br>
+notPrincipal**s** -> notPrincipal
+
+The old methods do still exist but are not what they used to be!
+
+---
+
 :warning: **Removed condition keys:**
 
 - events:SourceAccount

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ There are two different package variants available:
   [![PyPI CDK v1](https://img.shields.io/badge/pypi-0.286.0-yellow)](https://pypi.org/project/cdk-iam-floyd/0.286.0/)
 
   Starting with CDK v1.152.0 you have to use cdk-iam-floyd v0.286.0.<br>
-  Starting with CDK v2.20.0 you have to use cdk-iam-floyd >= v0.351.0.
+  Starting with CDK v2.20.0 you have to use cdk-iam-floyd >= v0.351.0.<br>
+  Starting with CDK v2.26.0 you have to use cdk-iam-floyd >= v0.377.0.
 
 Find them all on [libraries.io].
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -128,7 +128,7 @@ If instead you have an ARN ready, use the ``on()`` method:
 
 .. example:: resource-raw
 
-To invert the policy you can use ``notActions()``, ``notResources()`` and ``notPrincipals()``:
+To invert the policy you can use ``notAction()``, ``notResource()`` and ``notPrincipal()``:
 
 .. example:: notAction
 

--- a/docs/source/packages.rst
+++ b/docs/source/packages.rst
@@ -17,5 +17,11 @@ There are two different package variants available:
    | **Starting with version 0.300.0, the packages are compatible with CDK v2.** For CDK v1 you can use any version up to:
    | |cdk-iam-floyd-npm-v1|_ |cdk-iam-floyd-pypi-v1|_
 
+   Starting with CDK v1.152.0 you have to use cdk-iam-floyd v0.286.0.
+
+   Starting with CDK v2.20.0 you have to use cdk-iam-floyd >= v0.351.0.
+
+   Starting with CDK v2.26.0 you have to use cdk-iam-floyd >= v0.377.0.
+
 
 Find them all on `libraries.io`_.

--- a/docs/source/vocabulary.rst
+++ b/docs/source/vocabulary.rst
@@ -172,22 +172,22 @@ The CDK variant of the package has an additional method ``forCdkPrincipal``, whi
 .. WARNING::
    Make sure, you well understand the concepts of `notAction <NotAction_>`_, `notResource <NotResource_>`_ and `notPrincipal <NotPrincipal_>`_. This is where things quickly go wrong, especially when used in combination.
 
-notActions
-^^^^^^^^^^
+notAction
+^^^^^^^^^
 
 Switches the policy provider to use `NotAction`_.
 
 .. example:: notAction
 
-notResources
-^^^^^^^^^^^^
+notResource
+^^^^^^^^^^^
 
 Switches the policy provider to use `NotResource`_.
 
 .. example:: notResource
 
-notPrincipals
-^^^^^^^^^^^^^
+notPrincipal
+^^^^^^^^^^^^
 
 Switches the policy provider to use `NotPrincipal`_.
 

--- a/examples/notPrincipal/notPrincipal.ts
+++ b/examples/notPrincipal/notPrincipal.ts
@@ -7,7 +7,7 @@ function getStatement() {
     new statement.S3()
       .deny()
       .allActions()
-      .notPrincipals()
+      .notPrincipal()
       .forUser('1234567890', 'Bob')
       .onObject('example-bucket', '*')
     // doc-end

--- a/examples/notResource/notResource.ts
+++ b/examples/notResource/notResource.ts
@@ -6,7 +6,7 @@ function getStatement() {
     // doc-start
     new statement.S3()
       .allow()
-      .notResources()
+      .notResource()
       .toDeleteBucket()
       .onBucket('example-bucket')
     // doc-end

--- a/lib/shared/policy-statement/2-conditions.ts
+++ b/lib/shared/policy-statement/2-conditions.ts
@@ -19,7 +19,7 @@ export interface Conditions {
  * Adds "condition" functionality to the Policy Statement
  */
 export class PolicyStatementWithCondition extends PolicyStatementBase {
-  protected conditions: Conditions = {};
+  protected floydConditions: Conditions = {};
   private cdkConditionsApplied = false;
 
   /**
@@ -36,7 +36,7 @@ export class PolicyStatementWithCondition extends PolicyStatementBase {
     const statement = super.toJSON();
 
     if (this.hasConditions()) {
-      statement.Condition = this.conditions;
+      statement.Condition = this.floydConditions;
     }
 
     return statement;
@@ -50,10 +50,10 @@ export class PolicyStatementWithCondition extends PolicyStatementBase {
 
   private cdkApplyConditions() {
     if (this.hasConditions() && !this.cdkConditionsApplied) {
-      Object.keys(this.conditions).forEach((operator) => {
-        Object.keys(this.conditions[operator]).forEach((key) => {
+      Object.keys(this.floydConditions).forEach((operator) => {
+        Object.keys(this.floydConditions[operator]).forEach((key) => {
           const condition: any = {};
-          condition[key] = this.conditions[operator][key];
+          condition[key] = this.floydConditions[operator][key];
           // @ts-ignore only available after swapping 1-base
           this.addCondition(operator, condition);
         });
@@ -66,7 +66,7 @@ export class PolicyStatementWithCondition extends PolicyStatementBase {
    * Checks weather a condition was applied to the policy.
    */
   public hasConditions(): boolean {
-    return Object.keys(this.conditions).length > 0;
+    return Object.keys(this.floydConditions).length > 0;
   }
 
   /**
@@ -99,10 +99,10 @@ export class PolicyStatementWithCondition extends PolicyStatementBase {
       value = value.toString();
     }
 
-    if (!(op in this.conditions)) {
-      this.conditions[op] = {};
+    if (!(op in this.floydConditions)) {
+      this.floydConditions[op] = {};
     }
-    this.conditions[op][key] = value;
+    this.floydConditions[op][key] = value;
 
     return this;
   }

--- a/lib/shared/policy-statement/3-actions.ts
+++ b/lib/shared/policy-statement/3-actions.ts
@@ -19,8 +19,8 @@ export interface Action {
  */
 export class PolicyStatementWithActions extends PolicyStatementWithCondition {
   protected accessLevelList: AccessLevelList = {};
-  private useNotActions = false;
-  protected actions: string[] = [];
+  private useNotAction = false;
+  protected floydActions: string[] = [];
   private cdkActionsApplied = false;
   private isCompact = false;
 
@@ -35,7 +35,7 @@ export class PolicyStatementWithActions extends PolicyStatementWithCondition {
       this.cdkApplyActions();
       return super.toJSON();
     }
-    const mode = this.useNotActions ? 'NotAction' : 'Action';
+    const mode = this.useNotAction ? 'NotAction' : 'Action';
     const statement = super.toJSON();
     const self = this;
 
@@ -43,9 +43,9 @@ export class PolicyStatementWithActions extends PolicyStatementWithCondition {
       if (this.isCompact) {
         this.compactActions();
       }
-      const actions = this.actions
+      const actions = this.floydActions
         .filter((elem, pos) => {
-          return self.actions.indexOf(elem) == pos;
+          return self.floydActions.indexOf(elem) == pos;
         })
         .sort();
       statement[mode] = actions.length > 1 ? actions : actions[0];
@@ -62,14 +62,14 @@ export class PolicyStatementWithActions extends PolicyStatementWithCondition {
 
   private cdkApplyActions() {
     if (!this.cdkActionsApplied) {
-      const mode = this.useNotActions ? 'addNotActions' : 'addActions';
+      const mode = this.useNotAction ? 'addNotActions' : 'addActions';
       const self = this;
       if (this.isCompact) {
         this.compactActions();
       }
-      const uniqueActions = this.actions
+      const uniqueActions = this.floydActions
         .filter((elem, pos) => {
-          return self.actions.indexOf(elem) == pos;
+          return self.floydActions.indexOf(elem) == pos;
         })
         .sort();
       // @ts-ignore only available after swapping 1-base
@@ -81,8 +81,8 @@ export class PolicyStatementWithActions extends PolicyStatementWithCondition {
   /**
    * Switches the statement to use [`NotAction`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notaction.html).
    */
-  public notActions() {
-    this.useNotActions = true;
+  public notAction() {
+    this.useNotAction = true;
     return this;
   }
 
@@ -90,15 +90,15 @@ export class PolicyStatementWithActions extends PolicyStatementWithCondition {
    * Checks weather actions have been applied to the policy.
    */
   public hasActions(): boolean {
-    return this.actions.length > 0;
+    return this.floydActions.length > 0;
   }
 
   /**
    * Adds actions by name.
    *
-   * Depending on the "mode", actions will be either added to the list of [`Actions`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html) or [`NotActions`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notaction.html).
+   * Depending on the "mode", actions will be either added to the list of [`Actions`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_action.html) or [`NotAction`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notaction.html).
    *
-   * The mode can be switched by calling `notActions()`.
+   * The mode can be switched by calling `notAction()`.
    *
    * If the action does not contain a colon, the action will be prefixed with the service prefix of the class, e.g. `ec2:`
    *
@@ -109,7 +109,7 @@ export class PolicyStatementWithActions extends PolicyStatementWithCondition {
       action = this.servicePrefix + ':' + action;
     }
 
-    this.actions.push(action);
+    this.floydActions.push(action);
     return this;
   }
 
@@ -229,7 +229,7 @@ export class PolicyStatementWithActions extends PolicyStatementWithCondition {
 
   private compactActions() {
     // actions that will be included, service prefix is removed
-    const includeActions = this.actions.map((elem) => {
+    const includeActions = this.floydActions.map((elem) => {
       return elem.substr(elem.indexOf(':') + 1);
     });
 
@@ -307,6 +307,6 @@ export class PolicyStatementWithActions extends PolicyStatementWithCondition {
       });
 
     // we're done. override action list
-    this.actions = compactActionList;
+    this.floydActions = compactActionList;
   }
 }

--- a/lib/shared/policy-statement/4-resources.ts
+++ b/lib/shared/policy-statement/4-resources.ts
@@ -15,7 +15,7 @@ export interface ResourceType {
  * Adds "resource" functionality to the Policy Statement
  */
 export class PolicyStatementWithResources extends PolicyStatementWithActions {
-  private useNotResources = false;
+  private useNotResource = false;
   protected resources: string[] = [];
   protected skipAutoResource = false;
   private cdkResourcesApplied = false;
@@ -31,7 +31,7 @@ export class PolicyStatementWithResources extends PolicyStatementWithActions {
       this.cdkApplyResources();
       return super.toJSON();
     }
-    const mode = this.useNotResources ? 'NotResource' : 'Resource';
+    const mode = this.useNotResource ? 'NotResource' : 'Resource';
     const statement = super.toJSON();
     const self = this;
 
@@ -56,7 +56,7 @@ export class PolicyStatementWithResources extends PolicyStatementWithActions {
 
   private cdkApplyResources() {
     if (!this.cdkResourcesApplied) {
-      const mode = this.useNotResources ? 'addNotResources' : 'addResources';
+      const mode = this.useNotResource ? 'addNotResources' : 'addResources';
       const self = this;
       const uniqueResources = this.resources.filter((elem, pos) => {
         return self.resources.indexOf(elem) == pos;
@@ -70,8 +70,8 @@ export class PolicyStatementWithResources extends PolicyStatementWithActions {
   /**
    * Switches the statement to use [`NotResource`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html).
    */
-  public notResources() {
-    this.useNotResources = true;
+  public notResource() {
+    this.useNotResource = true;
     return this;
   }
 

--- a/lib/shared/policy-statement/6-principals.ts
+++ b/lib/shared/policy-statement/6-principals.ts
@@ -18,7 +18,7 @@ export enum PrincipalType {
  * Adds "principal" functionality to the Policy Statement
  */
 export class PolicyStatementWithPrincipal extends PolicyStatementWithEffect {
-  protected useNotPrincipals = false;
+  protected useNotPrincipal = false;
   protected myPrincipals: Principals = {};
 
   /**
@@ -33,7 +33,7 @@ export class PolicyStatementWithPrincipal extends PolicyStatementWithEffect {
       return super.toJSON();
     }
 
-    const mode = this.useNotPrincipals ? 'NotPrincipal' : 'Principal';
+    const mode = this.useNotPrincipal ? 'NotPrincipal' : 'Principal';
     const statement = super.toJSON();
 
     if (this.hasPrincipals()) {
@@ -54,8 +54,8 @@ export class PolicyStatementWithPrincipal extends PolicyStatementWithEffect {
   /**
    * Switches the statement to use [`notPrincipal`](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notprincipal.html).
    */
-  public notPrincipals() {
-    this.useNotPrincipals = true;
+  public notPrincipal() {
+    this.useNotPrincipal = true;
     return this;
   }
 
@@ -98,7 +98,10 @@ export class PolicyStatementWithPrincipal extends PolicyStatementWithEffect {
    */
   public forAccount(...accounts: string[]) {
     accounts.forEach((account) =>
-      this.addPrincipal(PrincipalType.AWS, `arn:${PolicyStatementWithPrincipal.defaultPartition}:iam::${account}:root`)
+      this.addPrincipal(
+        PrincipalType.AWS,
+        `arn:${PolicyStatementWithPrincipal.defaultPartition}:iam::${account}:root`
+      )
     );
     return this;
   }
@@ -166,7 +169,9 @@ export class PolicyStatementWithPrincipal extends PolicyStatementWithEffect {
    */
   public forSaml(account: string, ...providerNames: string[]) {
     providerNames.forEach((providerName) =>
-      this.forFederated(`arn:${PolicyStatementWithPrincipal.defaultPartition}:iam::${account}:saml-provider/${providerName}`)
+      this.forFederated(
+        `arn:${PolicyStatementWithPrincipal.defaultPartition}:iam::${account}:saml-provider/${providerName}`
+      )
     );
     return this;
   }

--- a/lib/shared/policy-statement/7-principals-CDK.ts
+++ b/lib/shared/policy-statement/7-principals-CDK.ts
@@ -22,7 +22,7 @@ export class PolicyStatementWithCDKPrincipal extends PolicyStatementWithPrincipa
 
   protected cdkApplyPrincipals() {
     if (!this.cdkPrincipalsApplied) {
-      const mode = this.useNotPrincipals ? 'addNotPrincipals' : 'addPrincipals';
+      const mode = this.useNotPrincipal ? 'addNotPrincipals' : 'addPrincipals';
       // @ts-ignore only available after swapping 1-base
       this[mode](...this.cdkPrincipals);
       if (this.hasPrincipals()) {


### PR DESCRIPTION
# :warning: BREAKING CHANGES

To restore compatibility with CDK [2.26.0](https://github.com/aws/aws-cdk/compare/v2.25.0...v2.26.0#diff-0ae3b84aa2e09276610b62695ce2b3485fde733b8ae0708053e6a075e17c6c11) some methods had to be renamed:

notAction**s** -> notAction<br>
notResource**s** -> notResource<br>
notPrincipal**s** -> notPrincipal