### PR TITLE
fix for when missing conditions are referenced

### DIFF
--- a/lib/generator/index.ts
+++ b/lib/generator/index.ts
@@ -819,6 +819,15 @@ function addActions($: CheerioStatic, module: Module): Module {
           module.servicePrefix!,
           cleanDescription($(conditionKey).text())
         );
+
+        if (!module.conditions![condition]) {
+          console.log(
+            `[Skipping referenced condition, since it is not documented: ${condition}]`
+              .red
+          );
+          return;
+        }
+
         conditions.push(condition);
         if (!('relatedActions' in module.conditions![condition])) {
           module.conditions![condition].relatedActions = [];


### PR DESCRIPTION
On https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2autoscaling.html#amazonec2autoscaling-autoscaling_TargetGroupARNs the condition TrafficSourceIdentifiers has been deleted, but it's still referenced in the actions table. A situation the generator was not prepared for yet.