### PR TITLE
replaces deprecated set-output w/ $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -47,7 +47,7 @@ jobs:
           set -x +e
           git stash -- package-lock.json
           git diff
-          echo ::set-output name=CHANGED::$(git diff --unified=0 -- stats | grep '^[+-]' | grep -v +++ | grep -v -- --- | wc -l | xargs)
+          echo "name=CHANGED::$(git diff --unified=0 -- stats | grep '^[+-]' | grep -v +++ | grep -v -- --- | wc -l | xargs)" >> $GITHUB_OUTPUT
 
       # fail if the index file does not exist.
       # this could happen if we cannot reach the AWS documentation, or the

--- a/.github/workflows/index-managed-policies.yml
+++ b/.github/workflows/index-managed-policies.yml
@@ -38,7 +38,7 @@ jobs:
           git stash -- package-lock.json
           git diff
           git diff --quiet
-          echo ::set-output name=CHANGED::$?
+          echo "name=CHANGED::$?" >> $GITHUB_OUTPUT
 
       - name: Configure git
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat VERSION)
+        run: echo "name=VERSION::$(cat VERSION)" >> $GITHUB_OUTPUT
 
       - name: Update version references
         run: make update-version-refs
@@ -75,7 +75,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -86,7 +86,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat VERSION)
+        run: echo "name=VERSION::$(cat VERSION)" >> $GITHUB_OUTPUT
 
       - name: Build source
         uses: udondan/jsii-publish@v0.14.0
@@ -121,7 +121,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -132,7 +132,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat VERSION)
+        run: echo "name=VERSION::$(cat VERSION)" >> $GITHUB_OUTPUT
 
       - name: Build CDK variant
         run: make install cdk
@@ -170,7 +170,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -214,7 +214,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -251,7 +251,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -297,7 +297,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -335,7 +335,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -346,7 +346,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat VERSION)
+        run: echo "name=VERSION::$(cat VERSION)" >> $GITHUB_OUTPUT
 
       - name: Create tag
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -55,7 +55,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat VERSION)
+        run: echo "name=VERSION::$(cat VERSION)" >> $GITHUB_OUTPUT
 
       - name: Build source
         uses: udondan/jsii-publish@v0.14.0
@@ -90,7 +90,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -101,7 +101,7 @@ jobs:
 
       - name: Get the version
         id: get_version
-        run: echo ::set-output name=VERSION::$(cat VERSION)
+        run: echo "name=VERSION::$(cat VERSION)" >> $GITHUB_OUTPUT
 
       - name: Build CDK variant
         run: make install cdk
@@ -139,7 +139,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -183,7 +183,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -220,7 +220,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3
@@ -266,7 +266,7 @@ jobs:
 
       - name: Store latest SHA as output
         id: get_sha
-        run: echo ::set-output name=SHA::$(cat /tmp/sha/sha)
+        run: echo "name=SHA::$(cat /tmp/sha/sha)" >> $GITHUB_OUTPUT
 
       - name: Checkout code
         uses: actions/checkout@v3

--- a/Test.Python.Makefile
+++ b/Test.Python.Makefile
@@ -4,6 +4,7 @@ install:
 	@pip3 uninstall --no-cache-dir -y iam-floyd
 	@pip3 install --no-cache-dir dist/python/iam-floyd-*.tar.gz
 	@pip3 install --no-cache-dir boto3
+	@pip3 install --force-reinstall "cryptography==38.0.4" # temporary fix https://github.com/aws/aws-sam-cli/issues/4527#issuecomment-1368871248
 
 install-cdk:
 	@pip3 uninstall --no-cache-dir -y cdk-iam-floyd


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/