### PR TITLE
refactor: changes exports structure to enable implementation of planned features

### DIFF
--- a/CHANGELOG/v0.603.0.md
+++ b/CHANGELOG/v0.603.0.md
@@ -1,0 +1,3 @@
+⚠️ BREAKING CHANGES
+
+- Restructures the exports of the package - see [#478](https://github.com/udondan/iam-floyd/pull/478)

--- a/docs/source/collections.rst
+++ b/docs/source/collections.rst
@@ -1,10 +1,35 @@
 Collections
 ===========
 
+.. NOTE::
+   The list of collections is not exhaustive. If you have a list of statements that you think is worth sharing with others, please open an issue or a `pull request <https://github.com/udondan/iam-floyd/tree/main/lib/collection>`_.
+
 .. include:: _warning.rst
 .. include:: _links.rst
 
-IAM Floyd provides commonly used statement collections. These can be called via:
+IAM Floyd provides commonly used statement collections.
+
+First import the ``Collection`` provider:
+
+.. tabs::
+
+   .. code-tab:: ts
+
+      // for use without AWS CDK use the iam-floyd package
+      import { Collection } from 'iam-floyd';
+
+      // for use with CDK use the cdk-iam-floyd package
+      import { Collection } from 'cdk-iam-floyd';
+
+   .. code-tab:: js
+
+      // for use without AWS CDK use the iam-floyd package
+      const { Collection } = require('iam-floyd');
+
+      // for use with CDK use the cdk-iam-floyd package
+      const { Collection } = require('cdk-iam-floyd');
+
+Collections then can be called via:
 
 .. example:: collection
 
@@ -18,4 +43,4 @@ Available collections
 allowEc2InstanceDeleteByOwner
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Allows stopping EC2 instance only for the user who started them.
+Allows stopping EC2 instance for the user who started them.

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -53,12 +53,15 @@ Once per day, at 2am UTC, the `AWS Documentation`_ is checked for updates. If an
 Do you release new packages when a new CDK version is released?
 ---------------------------------------------------------------
 
-No. I believe it's a myth and a user error if packages are incompatible with new releases of the CDK. ``cdk-iam-floyd`` is based on cdk ``^1.30.0`` and so far I have not seen any issues.
+No. I believe it's a myth and a user error if packages are incompatible with new releases of the CDK. ``cdk-iam-floyd`` is based on cdk ``^2.0.0`` and so far I have not seen any issues.
 
 Is the package following semantic versioning?
 ---------------------------------------------
 
-Mostly. For manual changes by developers this package follows `semver <https://semver.org/>`_.
+.. WARNING::
+   The package has not reached a stable state yet. Therefore breaking changes are not yet reflected by a major update!
+
+**When the package has reached version 1**, manual changes by developers of this package follow `semver <https://semver.org/>`_.
 
 Automatic releases triggered by changes in the IAM documentation will always result in a minor update.
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -9,25 +9,15 @@ Getting Started
 
 Depending on your scenario, you need to either install/import ``iam-floyd`` or ``cdk-iam-floyd``:
 
-.. tabs::
+.. code-block:: bash
 
-   .. code-tab:: bash JavaScript
+   # for use without AWS CDK use the iam-floyd package
+   npm install iam-floyd
 
-      # for use without AWS CDK use the iam-floyd package
-      npm install iam-floyd
-
-      # for use with CDK use the cdk-iam-floyd package
-      npm install cdk-iam-floyd
+   # for use with CDK use the cdk-iam-floyd package
+   npm install cdk-iam-floyd
 
 .. tabs::
-
-   .. code-tab:: js
-
-      // for use without AWS CDK use the iam-floyd package
-      const { Statement } = require('iam-floyd');
-
-      // for use with CDK use the cdk-iam-floyd package
-      const { Statement } = require('cdk-iam-floyd');
 
    .. code-tab:: ts
 
@@ -36,6 +26,14 @@ Depending on your scenario, you need to either install/import ``iam-floyd`` or `
 
       // for use with CDK use the cdk-iam-floyd package
       import { Statement } statement from 'cdk-iam-floyd';
+
+   .. code-tab:: js
+
+      // for use without AWS CDK use the iam-floyd package
+      const { Statement } = require('iam-floyd');
+
+      // for use with CDK use the cdk-iam-floyd package
+      const { Statement } = require('cdk-iam-floyd');
 
 Both packages contain a statement provider for each AWS service, e.g. ``Ec2``. A statement provider is a class with methods for each and every available action, resource type and condition. Calling such method will add the action/resource/condition to the statement:
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -32,10 +32,10 @@ Depending on your scenario, you need to either install/import ``iam-floyd`` or `
    .. code-tab:: ts
 
       // for use without AWS CDK use the iam-floyd package
-      import * as statement from 'iam-floyd';
+      import { Statement } from 'iam-floyd';
 
       // for use with CDK use the cdk-iam-floyd package
-      import * as statement from 'cdk-iam-floyd';
+      import { Statement } statement from 'cdk-iam-floyd';
 
 Both packages contain a statement provider for each AWS service, e.g. ``Ec2``. A statement provider is a class with methods for each and every available action, resource type and condition. Calling such method will add the action/resource/condition to the statement:
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -25,7 +25,7 @@ Depending on your scenario, you need to either install/import ``iam-floyd`` or `
       import { Statement } from 'iam-floyd';
 
       // for use with CDK use the cdk-iam-floyd package
-      import { Statement } statement from 'cdk-iam-floyd';
+      import { Statement } from 'cdk-iam-floyd';
 
    .. code-tab:: js
 

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -24,10 +24,10 @@ Depending on your scenario, you need to either install/import ``iam-floyd`` or `
    .. code-tab:: js
 
       // for use without AWS CDK use the iam-floyd package
-      var statement = require('iam-floyd');
+      const { Statement } = require('iam-floyd');
 
       // for use with CDK use the cdk-iam-floyd package
-      var statement = require('cdk-iam-floyd');
+      const { Statement } = require('cdk-iam-floyd');
 
    .. code-tab:: ts
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,6 +47,7 @@ Similar projects
 
 * `cdk-iam-actions <https://github.com/spacerat/cdk-iam-actions>`_
 * `cdk-iam-generator <https://github.com/srihariph/cdk-iam-generator>`_
+* `cdk-iam-policy-builder-helper <https://github.com/layerborn/cdk-iam-policy-builder-helper-construct>`_
 * `iam-policy-generator <https://github.com/aletheia/iam-policy-generator>`_
 * `policyuniverse <https://github.com/Netflix-Skunkworks/policyuniverse>`_
 * `policy_sentry <https://github.com/salesforce/policy_sentry>`_

--- a/docs/source/vocabulary.rst
+++ b/docs/source/vocabulary.rst
@@ -128,6 +128,28 @@ Operators
 
 `Condition operators <https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html>`_ can just be passed as strings. Or you can use the class ``Operator()``:
 
+First import the ``Operator`` class along with the ``Statement``:
+
+.. tabs::
+
+   .. code-tab:: ts
+
+      // for use without AWS CDK use the iam-floyd package
+      import { Operator, Statement } from 'iam-floyd';
+
+      // for use with CDK use the cdk-iam-floyd package
+      import { Operator, Statement } from 'cdk-iam-floyd';
+
+   .. code-tab:: js
+
+      // for use without AWS CDK use the iam-floyd package
+      const { Operator, Statement } = require('iam-floyd');
+
+      // for use with CDK use the cdk-iam-floyd package
+      const { Operator, Statement } = require('cdk-iam-floyd');
+
+Then it can be used like this:
+
 .. example:: conditions-operator-all-values
 
 .. example:: conditions-operator-any-value

--- a/docs/source/vocabulary.rst
+++ b/docs/source/vocabulary.rst
@@ -126,7 +126,7 @@ In case of `missing conditions <faq.html#are-all-actions-conditions-resource-typ
 Operators
 ^^^^^^^^^
 
-`Condition operators <https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html>`_ can just be passed as strings. Or you can use the class ``statement.Operator()``:
+`Condition operators <https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html>`_ can just be passed as strings. Or you can use the class ``Operator()``:
 
 .. example:: conditions-operator-all-values
 

--- a/examples/access-levels-list/access-levels-list.ts
+++ b/examples/access-levels-list/access-levels-list.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.S3() //
+    new Statement.S3() //
       .allow()
       .allListActions()
     // doc-end

--- a/examples/access-levels-permission-management/access-levels-permission-management.ts
+++ b/examples/access-levels-permission-management/access-levels-permission-management.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.S3() //
+    new Statement.S3() //
       .allow()
       .allPermissionManagementActions()
     // doc-end

--- a/examples/access-levels-read/access-levels-read.ts
+++ b/examples/access-levels-read/access-levels-read.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.S3() //
+    new Statement.S3() //
       .allow()
       .allReadActions()
     // doc-end

--- a/examples/access-levels-tagging/access-levels-tagging.ts
+++ b/examples/access-levels-tagging/access-levels-tagging.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.S3() //
+    new Statement.S3() //
       .allow()
       .allTaggingActions()
     // doc-end

--- a/examples/access-levels-write/access-levels-write.ts
+++ b/examples/access-levels-write/access-levels-write.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.S3() //
+    new Statement.S3() //
       .allow()
       .allWriteActions()
     // doc-end

--- a/examples/access-levels/access-levels.ts
+++ b/examples/access-levels/access-levels.ts
@@ -1,14 +1,14 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatements() {
   function wrap() {
     // doc-start
-    const s1 = new statement.S3() //
+    const s1 = new Statement.S3() //
       .deny()
       .allPermissionManagementActions();
 
-    const s2 = new statement.S3() //
+    const s2 = new Statement.S3() //
       .allow()
       .allListActions()
       .allReadActions();

--- a/examples/action-chaining/action-chaining.ts
+++ b/examples/action-chaining/action-chaining.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2() //
+    new Statement.Ec2() //
       .toStartInstances()
       .toStopInstances()
     // doc-end

--- a/examples/action-single/action-single.ts
+++ b/examples/action-single/action-single.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2().toStartInstances()
+    new Statement.Ec2().toStartInstances()
     // doc-end
   );
 }

--- a/examples/actions-all/actions-all.ts
+++ b/examples/actions-all/actions-all.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2() //
+    new Statement.Ec2() //
       .allow()
       .allActions()
     // doc-end

--- a/examples/actions-matching/actions-matching.ts
+++ b/examples/actions-matching/actions-matching.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2() //
+    new Statement.Ec2() //
       .deny()
       .allMatchingActions('/vpn/i')
     // doc-end

--- a/examples/actions-raw/actions-raw.ts
+++ b/examples/actions-raw/actions-raw.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2() //
+    new Statement.Ec2() //
       .allow()
       .to('missingAction')
     // doc-end

--- a/examples/allow-and-deny/allow-and-deny.ts
+++ b/examples/allow-and-deny/allow-and-deny.ts
@@ -1,14 +1,14 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatements() {
   function wrap() {
     // doc-start
-    const s1 = new statement.Ec2() //
+    const s1 = new Statement.Ec2() //
       .allow()
       .toStartInstances();
 
-    const s2 = new statement.Ec2() //
+    const s2 = new Statement.Ec2() //
       .deny()
       .toStopInstances();
     // doc-end

--- a/examples/allow/allow.ts
+++ b/examples/allow/allow.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2() //
+    new Statement.Ec2() //
       .allow()
       .toStartInstances()
       .toStopInstances()

--- a/examples/collection-policy/collection-policy.ts
+++ b/examples/collection-policy/collection-policy.ts
@@ -1,14 +1,12 @@
 import { deploy } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Collection } from '../../lib';
 
 function getPolicy() {
   function wrap() {
     // doc-start
     const policy = {
       Version: '2012-10-17',
-      Statement: [
-        ...new statement.Collection().allowEc2InstanceDeleteByOwner(),
-      ],
+      Statement: [...new Collection().allowEc2InstanceDeleteByOwner()],
     };
     // doc-end
     return policy;

--- a/examples/collection/collection.ts
+++ b/examples/collection/collection.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Collection } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Collection().allowEc2InstanceDeleteByOwner()
+    new Collection().allowEc2InstanceDeleteByOwner()
     // doc-end
   );
 }

--- a/examples/compact/compact.ts
+++ b/examples/compact/compact.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2() //
+    new Statement.Ec2() //
       .allow()
       .allReadActions()
       .allListActions()

--- a/examples/conditions-operator-all-values/conditions-operator-all-values.ts
+++ b/examples/conditions-operator-all-values/conditions-operator-all-values.ts
@@ -1,16 +1,16 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Operator, Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Dynamodb()
+    new Statement.Dynamodb()
       .allow()
       .toGetItem()
       .onTable('Thread')
       .ifAttributes(
         ['ID', 'Message', 'Tags'],
-        new statement.Operator().stringEquals().forAllValues(),
+        new Operator().stringEquals().forAllValues(),
       )
     // doc-end
   );

--- a/examples/conditions-operator-any-value/conditions-operator-any-value.ts
+++ b/examples/conditions-operator-any-value/conditions-operator-any-value.ts
@@ -1,16 +1,16 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Operator, Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Dynamodb()
+    new Statement.Dynamodb()
       .deny()
       .toPutItem()
       .onTable('Thread')
       .ifAttributes(
         ['ID', 'PostDateTime'],
-        new statement.Operator().stringEquals().forAnyValue(),
+        new Operator().stringEquals().forAnyValue(),
       )
     // doc-end
   );

--- a/examples/conditions-operator-if-exists/conditions-operator-if-exists.ts
+++ b/examples/conditions-operator-if-exists/conditions-operator-if-exists.ts
@@ -1,16 +1,16 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Operator, Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2()
+    new Statement.Ec2()
       .allow()
       .toStartInstances()
       .ifAwsRequestTag(
         'Environment',
         ['Production', 'Staging', 'Dev'],
-        new statement.Operator().stringEquals().ifExists(),
+        new Operator().stringEquals().ifExists(),
       )
     // doc-end
   );

--- a/examples/conditions-operator-string/conditions-operator-string.ts
+++ b/examples/conditions-operator-string/conditions-operator-string.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2()
+    new Statement.Ec2()
       .allow()
       .toStartInstances()
       .ifAwsRequestTag('TagWithSpecialChars', '*John*', 'StringEquals')

--- a/examples/conditions-raw/conditions-raw.ts
+++ b/examples/conditions-raw/conditions-raw.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2()
+    new Statement.Ec2()
       .allow()
       .toStartInstances()
       .if('ec2:missingCondition', 'some-value')

--- a/examples/conditions/conditions.ts
+++ b/examples/conditions/conditions.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2()
+    new Statement.Ec2()
       .allow()
       .toStartInstances()
       .ifEncrypted()

--- a/examples/deny/deny.ts
+++ b/examples/deny/deny.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2() //
+    new Statement.Ec2() //
       .deny()
       .toStartInstances()
       .toStopInstances()

--- a/examples/full-cdk-policy/full-cdk-policy.ts
+++ b/examples/full-cdk-policy/full-cdk-policy.ts
@@ -1,4 +1,4 @@
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getPolicy() {
   function wrap() {
@@ -6,22 +6,22 @@ function getPolicy() {
     const policy = {
       Version: '2012-10-17',
       Statement: [
-        new statement.Cloudformation() // allow all CFN actions
+        new Statement.Cloudformation() // allow all CFN actions
           .allow()
           .allActions(),
-        new statement.All() // allow absolutely everything that is triggered via CFN
+        new Statement.All() // allow absolutely everything that is triggered via CFN
           .allow()
           .allActions()
           .ifAwsCalledVia('cloudformation.amazonaws.com'),
-        new statement.S3() // allow access to the CDK staging bucket
+        new Statement.S3() // allow access to the CDK staging bucket
           .allow()
           .allActions()
           .on('arn:aws:s3:::cdktoolkit-stagingbucket-*'),
-        new statement.Account() // even when triggered via CFN, do not allow modifications of the account
+        new Statement.Account() // even when triggered via CFN, do not allow modifications of the account
           .deny()
           .allPermissionManagementActions()
           .allWriteActions(),
-        new statement.Organizations() // even when triggered via CFN, do not allow modifications of the organization
+        new Statement.Organizations() // even when triggered via CFN, do not allow modifications of the organization
           .deny()
           .allPermissionManagementActions()
           .allWriteActions(),

--- a/examples/full-ec2-stop-by-owner/full-ec2-stop-by-owner.ts
+++ b/examples/full-ec2-stop-by-owner/full-ec2-stop-by-owner.ts
@@ -1,4 +1,4 @@
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getPolicy() {
   function wrap() {
@@ -6,15 +6,15 @@ function getPolicy() {
     const policy = {
       Version: '2012-10-17',
       Statement: [
-        new statement.Ec2()
+        new Statement.Ec2()
           .allow()
           .toStartInstances()
           .ifAwsRequestTag('Owner', '${aws:username}'),
-        new statement.Ec2()
+        new Statement.Ec2()
           .allow()
           .toStopInstances()
           .ifResourceTag('Owner', '${aws:username}'),
-        new statement.Ec2() //
+        new Statement.Ec2() //
           .allow()
           .allListActions()
           .allReadActions(),

--- a/examples/no-chaining/no-chaining.ts
+++ b/examples/no-chaining/no-chaining.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   function wrap() {
     // doc-start
-    const myStatement = new statement.Ec2();
+    const myStatement = new Statement.Ec2();
     myStatement.allow();
     myStatement.toStartInstances();
     myStatement.toStopInstances();

--- a/examples/notAction/notAction.ts
+++ b/examples/notAction/notAction.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.S3()
+    new Statement.S3()
       .allow()
       .notAction()
       .toDeleteBucket()

--- a/examples/notPrincipal/notPrincipal.ts
+++ b/examples/notPrincipal/notPrincipal.ts
@@ -1,10 +1,10 @@
 import { out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.S3()
+    new Statement.S3()
       .deny()
       .allActions()
       .notPrincipal()

--- a/examples/notResource/notResource.ts
+++ b/examples/notResource/notResource.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.S3()
+    new Statement.S3()
       .allow()
       .notResource()
       .toDeleteBucket()

--- a/examples/principal-multiple/principal-multiple.ts
+++ b/examples/principal-multiple/principal-multiple.ts
@@ -1,29 +1,29 @@
 import { out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatements() {
   function wrap() {
     // doc-start
-    const s1 = new statement.Sts()
+    const s1 = new Statement.Sts()
       .allow()
       .toAssumeRole()
       .forAccount('1234567890', '0987654321');
 
     // when you already have a list:
     const accounts = ['1234567890', '0987654321'];
-    const s2 = new statement.Sts()
+    const s2 = new Statement.Sts()
       .allow()
       .toAssumeRole()
       .forAccount(...accounts);
 
-    const s3 = new statement.Sts()
+    const s3 = new Statement.Sts()
       .allow()
       .toAssumeRole()
       .forUser('1234567890', 'Bob', 'John');
 
     // when you already have a list:
     const users = ['Bob', 'John'];
-    const s4 = new statement.Sts()
+    const s4 = new Statement.Sts()
       .allow()
       .toAssumeRole()
       .forUser('1234567890', ...users);

--- a/examples/principal.cdk/principal.cdk.ts
+++ b/examples/principal.cdk/principal.cdk.ts
@@ -1,12 +1,12 @@
 import { aws_iam as iam } from 'aws-cdk-lib';
 
 import { out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Sts()
+    new Statement.Sts()
       .allow()
       .toAssumeRole()
       .forCdkPrincipal(

--- a/examples/principal/principal.ts
+++ b/examples/principal/principal.ts
@@ -1,70 +1,70 @@
 import { out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatements() {
   function wrap() {
     // doc-start
-    const s1 = new statement.Sts()
+    const s1 = new Statement.Sts()
       .allow()
       .toAssumeRole()
       .forAccount('1234567890');
 
-    const s2 = new statement.Sts()
+    const s2 = new Statement.Sts()
       .allow()
       .toAssumeRoleWithSAML()
       .forService('lambda.amazonaws.com');
 
-    const s3 = new statement.Sts()
+    const s3 = new Statement.Sts()
       .allow()
       .toAssumeRole()
       .forUser('1234567890', 'Bob');
 
-    const s4 = new statement.Sts()
+    const s4 = new Statement.Sts()
       .allow()
       .toAssumeRole()
       .forRole('1234567890', 'role-name');
 
-    const s5 = new statement.Sts()
+    const s5 = new Statement.Sts()
       .allow()
       .toAssumeRoleWithSAML()
       .forFederatedCognito();
 
-    const s6 = new statement.Sts()
+    const s6 = new Statement.Sts()
       .allow()
       .toAssumeRoleWithSAML()
       .forFederatedAmazon();
 
-    const s7 = new statement.Sts()
+    const s7 = new Statement.Sts()
       .allow()
       .toAssumeRoleWithSAML()
       .forFederatedGoogle();
 
-    const s8 = new statement.Sts()
+    const s8 = new Statement.Sts()
       .allow()
       .toAssumeRoleWithSAML()
       .forFederatedFacebook();
 
-    const s9 = new statement.Sts()
+    const s9 = new Statement.Sts()
       .allow()
       .toAssumeRoleWithSAML()
       .forSaml('1234567890', 'saml-provider');
 
-    const s10 = new statement.Sts() //
+    const s10 = new Statement.Sts() //
       .allow()
       .toAssumeRole()
       .forPublic();
 
-    const s11 = new statement.Sts()
+    const s11 = new Statement.Sts()
       .allow()
       .toAssumeRole()
       .forAssumedRoleSession('123456789', 'role-name', 'session-name');
 
-    const s12 = new statement.Sts()
+    const s12 = new Statement.Sts()
       .allow()
       .toAssumeRole()
       .forCanonicalUser('userID');
 
-    const s13 = new statement.Sts() //
+    const s13 = new Statement.Sts() //
       .allow()
       .toAssumeRole()
       .for('arn:foo:bar');

--- a/examples/resource-raw/resource-raw.ts
+++ b/examples/resource-raw/resource-raw.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.S3() //
+    new Statement.S3() //
       .allow()
       .allActions()
       .on(

--- a/examples/resource/resource.ts
+++ b/examples/resource/resource.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.S3()
+    new Statement.S3()
       .allow()
       .allActions()
       .onBucket('example-bucket')

--- a/examples/sid/sid.ts
+++ b/examples/sid/sid.ts
@@ -1,10 +1,10 @@
 import { deploy, out } from '../../helper/typescript/typescript_test';
-import * as statement from '../../lib';
+import { Statement } from '../../lib';
 
 function getStatement() {
   return (
     // doc-start
-    new statement.Ec2('MYSID') //
+    new Statement.Ec2('MYSID') //
       .allow()
       .toStartInstances()
       .toStopInstances()

--- a/lib/collection/allowEc2InstanceDeleteByOwner.ts
+++ b/lib/collection/allowEc2InstanceDeleteByOwner.ts
@@ -1,4 +1,4 @@
-import * as statement from '..';
+import { Statement } from '..';
 
 /**
  * Allows stopping EC2 instance only for the user who started them
@@ -9,11 +9,11 @@ import * as statement from '..';
 export function allowEc2InstanceDeleteByOwner(tag?: string) {
   const tagName = tag ?? 'Owner';
   return [
-    new statement.Ec2()
+    new Statement.Ec2()
       .allow()
       .toStartInstances()
       .ifAwsRequestTag(tagName, '${aws:username}'),
-    new statement.Ec2()
+    new Statement.Ec2()
       .allow()
       .toStopInstances()
       .ifResourceTag(tagName, '${aws:username}'),

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,4 @@
-export * from './shared';
-export * from './generated';
-export * from './collection';
+export { Collection } from './collection';
+export { Operator, PolicyStatement } from './shared';
 export { AccessLevelList } from './shared/access-level';
+export * as Statement from './statements';

--- a/lib/statements.ts
+++ b/lib/statements.ts
@@ -1,0 +1,2 @@
+export { All } from './shared/all';
+export * from './generated';

--- a/test/cdk.ts
+++ b/test/cdk.ts
@@ -1,6 +1,11 @@
-import { App, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
-import * as iam from 'aws-cdk-lib/aws-iam';
-import * as s3 from 'aws-cdk-lib/aws-s3';
+import {
+  App,
+  aws_iam,
+  aws_s3,
+  RemovalPolicy,
+  Stack,
+  StackProps,
+} from 'aws-cdk-lib';
 import { Statement } from 'cdk-iam-floyd';
 import { Construct } from 'constructs';
 
@@ -8,7 +13,7 @@ export class TestStack extends Stack {
   constructor(scope: Construct, id: string, props?: StackProps) {
     super(scope, id, props);
 
-    const policy = new iam.ManagedPolicy(this, 'Policy', {
+    const policy = new aws_iam.ManagedPolicy(this, 'Policy', {
       managedPolicyName: `${this.stackName}-testpolicy`,
       description: `test policy`,
       statements: [
@@ -37,14 +42,14 @@ export class TestStack extends Stack {
       ],
     });
 
-    const role = new iam.Role(this, 'Role', {
+    const role = new aws_iam.Role(this, 'Role', {
       roleName: `${this.stackName}-testrole`,
       description: 'Test Role',
-      assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
+      assumedBy: new aws_iam.ServicePrincipal('lambda.amazonaws.com'),
       managedPolicies: [policy],
     });
 
-    const bucket = new s3.Bucket(this, 'Bucket', {
+    const bucket = new aws_s3.Bucket(this, 'Bucket', {
       removalPolicy: RemovalPolicy.DESTROY,
     });
 

--- a/test/cdk.ts
+++ b/test/cdk.ts
@@ -1,7 +1,7 @@
 import { App, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as s3 from 'aws-cdk-lib/aws-s3';
-import * as statement from 'cdk-iam-floyd';
+import { Statement } from 'cdk-iam-floyd';
 import { Construct } from 'constructs';
 
 export class TestStack extends Stack {
@@ -12,17 +12,17 @@ export class TestStack extends Stack {
       managedPolicyName: `${this.stackName}-testpolicy`,
       description: `test policy`,
       statements: [
-        new statement.Ssm()
+        new Statement.Ssm()
           .allow()
           .toListDocuments()
           .toListTagsForResource()
           .onInstance('i-1234567890'),
-        new statement.Ssm()
+        new Statement.Ssm()
           .allow()
           .toCreateDocument()
           .toAddTagsToResource()
           .ifAwsRequestTag('CreatedBy', 'Bob'),
-        new statement.Ssm()
+        new Statement.Ssm()
           .allow()
           .toDeleteDocument()
           .toDescribeDocument()
@@ -49,7 +49,7 @@ export class TestStack extends Stack {
     });
 
     bucket.addToResourcePolicy(
-      new statement.S3() //
+      new Statement.S3() //
         .allow()
         .toGetObject()
         .onObject(bucket.bucketName, '*')

--- a/test/main.ts
+++ b/test/main.ts
@@ -1,4 +1,4 @@
-import { Collection, Statement } from 'cdk-iam-floyd';
+import { Collection, Operator, Statement } from 'cdk-iam-floyd';
 
 function printPolicyWithStatements(statements: any[]) {
   console.log(
@@ -41,8 +41,5 @@ printPolicyWithStatements([
   new Statement.Ec2()
     .allow()
     .allPermissionManagementActions()
-    .ifAwsSourceIp(
-      '1.2.3.4',
-      new Statement.Operator().notIpAddress().ifExists(),
-    ),
+    .ifAwsSourceIp('1.2.3.4', new Operator().notIpAddress().ifExists()),
 ]);

--- a/test/main.ts
+++ b/test/main.ts
@@ -1,4 +1,4 @@
-import * as statement from 'cdk-iam-floyd';
+import { Collection, Statement } from 'cdk-iam-floyd';
 
 function printPolicyWithStatements(statements: any[]) {
   console.log(
@@ -14,37 +14,35 @@ function printPolicyWithStatements(statements: any[]) {
 }
 
 printPolicyWithStatements([
-  new statement.Sts() //
+  new Statement.Sts() //
     .allow()
     .toAssumeRole()
     .forService('rds.amazonaws.com'),
 ]);
 
-printPolicyWithStatements(
-  new statement.Collection().allowEc2InstanceDeleteByOwner(),
-);
+printPolicyWithStatements(new Collection().allowEc2InstanceDeleteByOwner());
 
 printPolicyWithStatements([
-  new statement.Secretsmanager()
+  new Statement.Secretsmanager()
     .allow()
     .allActions()
     .ifResourceTag('CreatedBy', 'me'),
 ]);
 
 printPolicyWithStatements([
-  new statement.Ec2().allow().allMatchingActions('/vpn/i'),
+  new Statement.Ec2().allow().allMatchingActions('/vpn/i'),
 ]);
 
 printPolicyWithStatements([
-  new statement.Ec2().allow().allPermissionManagementActions(),
+  new Statement.Ec2().allow().allPermissionManagementActions(),
 ]);
 
 printPolicyWithStatements([
-  new statement.Ec2()
+  new Statement.Ec2()
     .allow()
     .allPermissionManagementActions()
     .ifAwsSourceIp(
       '1.2.3.4',
-      new statement.Operator().notIpAddress().ifExists(),
+      new Statement.Operator().notIpAddress().ifExists(),
     ),
 ]);


### PR DESCRIPTION
Restructures the exports of the package. Previously everything was exported on the top level of the package and to get to Operators you would need to do `statement.Operatores()`, which didn't make sense. This was the result of a [limitation in jsii](https://github.com/aws/jsii/issues/2773).

Now that we have dropped jsii and Python support we can pave the way for future feature implementation.

⚠️ This is a breaking change and all users need to update their imports.

Previously you were instructed to import like this:

```ts
import * as statement from '(cdk-)iam-cloyd';
```

Now you can and have to import `Statement` and `Operator` separately:

```ts
import {Operator, Statement} from '(cdk-)iam-cloyd';
```

If you imported the statement providers directly, you do not have to change anything. Both of this still works:

```ts
import { Ec2 } from '(cdk-)iam-cloyd/lib/generated';
import { Ec2 } from '(cdk-)iam-cloyd/lib/generated/ec2';
```

But it _could_ be also changeed to this, which read nicer:

```ts
import { Ec2 } from '(cdk-)iam-cloyd/lib/statements';
import { Ec2 } from '(cdk-)iam-cloyd/lib/statements/ec2';
```