### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AmazonRDSCustomServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/AmazonRDSCustomServiceRolePolicy.json
@@ -12,6 +12,7 @@
         "ec2:DescribeNetworkInterfaces",
         "ec2:DescribeVolumes",
         "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstanceTypes",
         "ec2:DescribeIamInstanceProfileAssociations",
         "ec2:DescribeImages",
         "ec2:DescribeVpcs",
@@ -161,6 +162,24 @@
             "custom-oracle-rac",
             "custom-oracle"
           ]
+        }
+      }
+    },
+    {
+      "Sid": "eccModifyInstanceAttribute1",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:ModifyInstanceAttribute"
+      ],
+      "Resource": [
+        "arn:aws:ec2:*:*:instance/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/AWSRDSCustom": [
+            "custom-sqlserver"
+          ],
+          "ec2:Attribute": "InstanceType"
         }
       }
     },

--- a/docs/source/_static/managed-policies/CloudWatchApplicationSignalsServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/CloudWatchApplicationSignalsServiceRolePolicy.json
@@ -33,10 +33,9 @@
       }
     },
     {
-      "Sid": "CWMetricsPermission",
+      "Sid": "CWListMetricsPermission",
       "Effect": "Allow",
       "Action": [
-        "cloudwatch:GetMetricData",
         "cloudwatch:ListMetrics"
       ],
       "Resource": [
@@ -47,6 +46,16 @@
           "aws:ResourceAccount": "${aws:PrincipalAccount}"
         }
       }
+    },
+    {
+      "Sid": "CWGetMetricDataPermission",
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:GetMetricData"
+      ],
+      "Resource": [
+        "*"
+      ]
     },
     {
       "Sid": "TagsPermission",


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the managed policy documentation to include new permissions for Amazon RDS and CloudWatch. This includes:
		- Allowing modification of instance attributes for specific tagged instances in Amazon RDS.
		- Renaming a permission and adding a new permission for CloudWatch to enhance metrics data access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->