### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AmazonConnectServiceLinkedRolePolicy.json
+++ b/docs/source/_static/managed-policies/AmazonConnectServiceLinkedRolePolicy.json
@@ -194,6 +194,30 @@
           "aws:ResourceAccount": "${aws:PrincipalAccount}"
         }
       }
+    },
+    {
+      "Sid": "AllowCognitoForConnectEnabledTaggedResources",
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPool",
+        "cognito-idp:ListUserPoolClients"
+      ],
+      "Resource": "arn:aws:cognito-idp:*:*:userpool/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/AmazonConnectEnabled": "True"
+        }
+      }
+    },
+    {
+      "Sid": "AllowWritePermissionForCustomerProfileObjects",
+      "Effect": "Allow",
+      "Action": [
+        "profile:PutProfileObject"
+      ],
+      "Resource": [
+        "arn:aws:profile:*:*:domains/amazon-connect-*/object-types/*"
+      ]
     }
   ]
 }

--- a/docs/source/_static/managed-policies/AmazonSQSReadOnlyAccess.json
+++ b/docs/source/_static/managed-policies/AmazonSQSReadOnlyAccess.json
@@ -2,13 +2,15 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "AmazonSQSReadOnlyAccess",
       "Effect": "Allow",
       "Action": [
         "sqs:GetQueueAttributes",
         "sqs:GetQueueUrl",
         "sqs:ListDeadLetterSourceQueues",
         "sqs:ListQueues",
-        "sqs:ListMessageMoveTasks"
+        "sqs:ListMessageMoveTasks",
+        "sqs:ListQueueTags"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Amazon Connect Service Linked Role Policy to include permissions for Cognito user pools and customer profile objects.
  - Enhanced Amazon SQS Read-Only Access Policy with the ability to list queue tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->