### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AmazonSageMakerAdmin-ServiceCatalogProductsServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/AmazonSageMakerAdmin-ServiceCatalogProductsServiceRolePolicy.json
@@ -2,7 +2,6 @@
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "AmazonSageMakerServiceCatalogAPIGatewayPermission",
       "Effect": "Allow",
       "Action": [
         "apigateway:GET",
@@ -19,7 +18,6 @@
       }
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogAPIGatewayPostPermission",
       "Effect": "Allow",
       "Action": [
         "apigateway:POST"
@@ -34,7 +32,6 @@
       }
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogAPIGatewayPatchPermission",
       "Effect": "Allow",
       "Action": [
         "apigateway:PATCH"
@@ -44,7 +41,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogCFnMutatePermission",
       "Effect": "Allow",
       "Action": [
         "cloudformation:CreateStack",
@@ -61,21 +57,6 @@
       }
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogCFnTagPermission",
-      "Effect": "Allow",
-      "Action": [
-        "cloudformation:TagResource",
-        "cloudformation:UntagResource"
-      ],
-      "Resource": "arn:aws:cloudformation:*:*:stack/SC-*",
-      "Condition": {
-        "Null": {
-          "aws:ResourceTag/sagemaker:project-name": "false"
-        }
-      }
-    },
-    {
-      "Sid": "AmazonSageMakerServiceCatalogCFnReadPermission",
       "Effect": "Allow",
       "Action": [
         "cloudformation:DescribeStackEvents",
@@ -84,7 +65,6 @@
       "Resource": "arn:aws:cloudformation:*:*:stack/SC-*"
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogCFnTemplatePermission",
       "Effect": "Allow",
       "Action": [
         "cloudformation:GetTemplateSummary",
@@ -93,7 +73,6 @@
       "Resource": "*"
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogCodeBuildPermission",
       "Effect": "Allow",
       "Action": [
         "codebuild:CreateProject",
@@ -105,7 +84,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogCodeCommitPermission",
       "Effect": "Allow",
       "Action": [
         "codecommit:CreateCommit",
@@ -119,7 +97,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogCodeCommitListPermission",
       "Effect": "Allow",
       "Action": [
         "codecommit:ListRepositories"
@@ -127,7 +104,6 @@
       "Resource": "*"
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogCodePipelinePermission",
       "Effect": "Allow",
       "Action": [
         "codepipeline:CreatePipeline",
@@ -143,7 +119,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogCIAMUserPermission",
       "Effect": "Allow",
       "Action": [
         "cognito-idp:CreateUserPool",
@@ -159,7 +134,6 @@
       }
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogCIAMPermission",
       "Effect": "Allow",
       "Action": [
         "cognito-idp:CreateGroup",
@@ -182,7 +156,6 @@
       }
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogECRPermission",
       "Effect": "Allow",
       "Action": [
         "ecr:CreateRepository",
@@ -194,7 +167,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogEventBridgePermission",
       "Effect": "Allow",
       "Action": [
         "events:DescribeRule",
@@ -210,7 +182,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogFirehosePermission",
       "Effect": "Allow",
       "Action": [
         "firehose:CreateDeliveryStream",
@@ -223,7 +194,6 @@
       "Resource": "arn:aws:firehose:*:*:deliverystream/sagemaker-*"
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogGluePermission",
       "Effect": "Allow",
       "Action": [
         "glue:CreateDatabase",
@@ -237,7 +207,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogGlueClassiferPermission",
       "Effect": "Allow",
       "Action": [
         "glue:CreateClassifier",
@@ -253,7 +222,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogGlueWorkflowPermission",
       "Effect": "Allow",
       "Action": [
         "glue:CreateWorkflow"
@@ -263,7 +231,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogGlueJobPermission",
       "Effect": "Allow",
       "Action": [
         "glue:CreateJob"
@@ -273,7 +240,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogGlueCrawlerPermission",
       "Effect": "Allow",
       "Action": [
         "glue:CreateCrawler",
@@ -284,7 +250,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogGlueTriggerPermission",
       "Effect": "Allow",
       "Action": [
         "glue:CreateTrigger",
@@ -295,7 +260,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogPassRolePermission",
       "Effect": "Allow",
       "Action": [
         "iam:PassRole"
@@ -305,7 +269,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogLambdaPermission",
       "Effect": "Allow",
       "Action": [
         "lambda:AddPermission",
@@ -321,7 +284,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogLambdaTagPermission",
       "Effect": "Allow",
       "Action": "lambda:TagResource",
       "Resource": [
@@ -336,7 +298,6 @@
       }
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogLogGroupPermission",
       "Effect": "Allow",
       "Action": [
         "logs:CreateLogGroup",
@@ -353,7 +314,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogS3ReadPermission",
       "Effect": "Allow",
       "Action": "s3:GetObject",
       "Resource": "*",
@@ -364,7 +324,6 @@
       }
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogS3ReadSagemakerResourcePermission",
       "Effect": "Allow",
       "Action": "s3:GetObject",
       "Resource": [
@@ -372,7 +331,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogS3MutatePermission",
       "Effect": "Allow",
       "Action": [
         "s3:CreateBucket",
@@ -392,7 +350,6 @@
       "Resource": "arn:aws:s3:::sagemaker-*"
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogSageMakerPermission",
       "Effect": "Allow",
       "Action": [
         "sagemaker:CreateEndpoint",
@@ -417,7 +374,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogSageMakerTagPermission",
       "Effect": "Allow",
       "Action": [
         "sagemaker:AddTags"
@@ -439,7 +395,6 @@
       }
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogSageMakerImagePermission",
       "Effect": "Allow",
       "Action": [
         "sagemaker:CreateImage",
@@ -453,7 +408,6 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogStepFunctionPermission",
       "Effect": "Allow",
       "Action": [
         "states:CreateStateMachine",
@@ -465,30 +419,12 @@
       ]
     },
     {
-      "Sid": "AmazonSageMakerServiceCatalogCodeStarPermission",
       "Effect": "Allow",
       "Action": "codestar-connections:PassConnection",
       "Resource": "arn:aws:codestar-connections:*:*:connection/*",
       "Condition": {
-        "StringEqualsIgnoreCase": {
-          "aws:ResourceTag/sagemaker": "true"
-        },
         "StringEquals": {
           "codestar-connections:PassedToService": "codepipeline.amazonaws.com"
-        }
-      }
-    },
-    {
-      "Sid": "AmazonSageMakerServiceCatalogCodeConnectionPermission",
-      "Effect": "Allow",
-      "Action": "codeconnections:PassConnection",
-      "Resource": "arn:aws:codeconnections:*:*:connection/*",
-      "Condition": {
-        "StringEqualsIgnoreCase": {
-          "aws:ResourceTag/sagemaker": "true"
-        },
-        "StringEquals": {
-          "codeconnections:PassedToService": "codepipeline.amazonaws.com"
         }
       }
     }


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed multiple permission statements from the Amazon SageMaker Admin Service Catalog Products Service Role Policy to streamline and simplify permissions across various AWS services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->