### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AmazonAthenaFullAccess.json
+++ b/docs/source/_static/managed-policies/AmazonAthenaFullAccess.json
@@ -36,7 +36,8 @@
         "glue:BatchGetPartition",
         "glue:StartColumnStatisticsTaskRun",
         "glue:GetColumnStatisticsTaskRun",
-        "glue:GetColumnStatisticsTaskRuns"
+        "glue:GetColumnStatisticsTaskRuns",
+        "glue:GetCatalogImportStatus"
       ],
       "Resource": [
         "*"

--- a/docs/source/_static/managed-policies/ComputeOptimizerReadOnlyAccess.json
+++ b/docs/source/_static/managed-policies/ComputeOptimizerReadOnlyAccess.json
@@ -2,6 +2,7 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "computeOptimizerReadOnlyAccess",
       "Effect": "Allow",
       "Action": [
         "compute-optimizer:DescribeRecommendationExportJobs",
@@ -17,6 +18,8 @@
         "compute-optimizer:GetEffectiveRecommendationPreferences",
         "compute-optimizer:GetECSServiceRecommendations",
         "compute-optimizer:GetECSServiceRecommendationProjectedMetrics",
+        "compute-optimizer:GetRDSDatabaseRecommendations",
+        "compute-optimizer:GetRDSDatabaseRecommendationProjectedMetrics",
         "compute-optimizer:GetLicenseRecommendations",
         "ec2:DescribeInstances",
         "ec2:DescribeVolumes",
@@ -29,7 +32,9 @@
         "cloudwatch:GetMetricData",
         "organizations:ListAccounts",
         "organizations:DescribeOrganization",
-        "organizations:DescribeAccount"
+        "organizations:DescribeAccount",
+        "rds:DescribeDBInstances",
+        "rds:DescribeDBClusters"
       ],
       "Resource": "*"
     }


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated `AmazonAthenaFullAccess` policy to include `glue:GetCatalogImportStatus` permission.
  - Enhanced `ComputeOptimizerReadOnlyAccess` policy with new permissions for RDS database recommendations and additional RDS instance and cluster descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->