### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AmazonSSMManagedEC2InstanceDefaultPolicy.json
+++ b/docs/source/_static/managed-policies/AmazonSSMManagedEC2InstanceDefaultPolicy.json
@@ -2,6 +2,7 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "AllowSSMAgentPermissions",
       "Effect": "Allow",
       "Action": [
         "ssm:DescribeAssociation",
@@ -21,6 +22,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "AllowSSMChannelMessaging",
       "Effect": "Allow",
       "Action": [
         "ssmmessages:CreateControlChannel",
@@ -31,6 +33,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "AllowSSMLegacyMessaging",
       "Effect": "Allow",
       "Action": [
         "ec2messages:AcknowledgeMessage",


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated Amazon SSM managed EC2 instance default policy to include permissions for managing SSM agent, SSM channel messaging, and SSM legacy messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->