### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSDataExchangeReadOnly.json
+++ b/docs/source/_static/managed-policies/AWSDataExchangeReadOnly.json
@@ -2,14 +2,25 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "DataExchangeReadOnlyActions",
       "Effect": "Allow",
       "Action": [
-        "dataexchange:Get*",
-        "dataexchange:List*"
+        "dataexchange:GetAsset",
+        "dataexchange:GetDataSet",
+        "dataexchange:GetEventAction",
+        "dataexchange:GetJob",
+        "dataexchange:GetRevision",
+        "dataexchange:ListDataSetRevisions",
+        "dataexchange:ListDataSets",
+        "dataexchange:ListEventActions",
+        "dataexchange:ListJobs",
+        "dataexchange:ListRevisionAssets",
+        "dataexchange:ListTagsForResource"
       ],
       "Resource": "*"
     },
     {
+      "Sid": "AWSMarketplaceReadOnlyActions",
       "Effect": "Allow",
       "Action": [
         "aws-marketplace:ViewSubscriptions",
@@ -22,7 +33,9 @@
         "aws-marketplace:DescribeChangeSet",
         "aws-marketplace:ListChangeSets",
         "aws-marketplace:SearchAgreements",
-        "aws-marketplace:GetAgreementTerms"
+        "aws-marketplace:GetAgreementTerms",
+        "aws-marketplace:ListPrivateListings",
+        "aws-marketplace:ListTagsForResource"
       ],
       "Resource": "*"
     }

--- a/docs/source/_static/managed-policies/AWSDataSyncFullAccess.json
+++ b/docs/source/_static/managed-policies/AWSDataSyncFullAccess.json
@@ -10,6 +10,7 @@
         "ec2:CreateNetworkInterfacePermission",
         "ec2:DeleteNetworkInterface",
         "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeRegions",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeSubnets",
         "ec2:DescribeVpcEndpoints",

--- a/docs/source/_static/managed-policies/AWSElementalMediaLiveReadOnly.json
+++ b/docs/source/_static/managed-policies/AWSElementalMediaLiveReadOnly.json
@@ -1,11 +1,15 @@
 {
   "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": [
-      "medialive:List*",
-      "medialive:Describe*"
-    ],
-    "Resource": "*"
-  }
+  "Statement": [
+    {
+      "Sid": "AWSElementalMediaLiveReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "medialive:Get*",
+        "medialive:List*",
+        "medialive:Describe*"
+      ],
+      "Resource": "*"
+    }
+  ]
 }

--- a/docs/source/_static/managed-policies/FMSServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/FMSServiceRolePolicy.json
@@ -557,7 +557,9 @@
         "network-firewall:DescribeResourcePolicy",
         "network-firewall:DeleteResourcePolicy",
         "network-firewall:DescribeLoggingConfiguration",
-        "network-firewall:UpdateLoggingConfiguration"
+        "network-firewall:UpdateLoggingConfiguration",
+        "network-firewall:DescribeTLSInspectionConfiguration",
+        "network-firewall:ListTLSInspectionConfigurations"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced permission granularity in policies for AWS Data Exchange and AWS Marketplace, allowing for more secure read-only access.
	- Added ability to describe EC2 regions in the AWS DataSync policy for better resource management.
	- Expanded permissions in AWS Elemental MediaLive to include additional access actions.
	- Introduced new permissions for managing TLS inspection configurations in the AWS Network Firewall policy.

- **Bug Fixes**
	- Resolved inconsistencies in policy structure for AWS Elemental MediaLive, improving future scalability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->