### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSBackupOperatorAccess.json
+++ b/docs/source/_static/managed-policies/AWSBackupOperatorAccess.json
@@ -2,6 +2,7 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "AwsBackupAllAccess",
       "Effect": "Allow",
       "Action": [
         "backup:Get*",
@@ -16,6 +17,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "RDSDescribeAccess",
       "Effect": "Allow",
       "Action": [
         "rds:DescribeDBSnapshots",
@@ -35,6 +37,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "DynamoDBAccess",
       "Effect": "Allow",
       "Action": [
         "dynamodb:ListBackups",
@@ -43,6 +46,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "EFSAccess",
       "Effect": "Allow",
       "Action": [
         "elasticfilesystem:DescribeFilesystems"
@@ -50,6 +54,7 @@
       "Resource": "arn:aws:elasticfilesystem:*:*:file-system/*"
     },
     {
+      "Sid": "EC2Access",
       "Effect": "Allow",
       "Action": [
         "ec2:DescribeSnapshots",
@@ -69,6 +74,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "TagReadAccess",
       "Effect": "Allow",
       "Action": [
         "tag:GetTagKeys",
@@ -78,6 +84,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "StorageGatewaySCSIAccess",
       "Effect": "Allow",
       "Action": [
         "storagegateway:DescribeCachediSCSIVolumes",
@@ -86,6 +93,7 @@
       "Resource": "arn:aws:storagegateway:*:*:gateway/*/volume/*"
     },
     {
+      "Sid": "StorageGatewayReadAccess",
       "Effect": "Allow",
       "Action": [
         "storagegateway:ListGateways"
@@ -93,15 +101,24 @@
       "Resource": "arn:aws:storagegateway:*:*:*"
     },
     {
+      "Sid": "StorageGatewayDiskReadAccess",
       "Effect": "Allow",
       "Action": [
         "storagegateway:DescribeGatewayInformation",
-        "storagegateway:ListVolumes",
         "storagegateway:ListLocalDisks"
       ],
       "Resource": "arn:aws:storagegateway:*:*:gateway/*"
     },
     {
+      "Sid": "StorageGatewayVolumeReadAccess",
+      "Effect": "Allow",
+      "Action": [
+        "storagegateway:ListVolumes"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "IAMRoleAccess",
       "Effect": "Allow",
       "Action": [
         "iam:ListRoles",
@@ -110,6 +127,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "PassRoleAccess",
       "Effect": "Allow",
       "Action": "iam:PassRole",
       "Resource": [
@@ -123,11 +141,13 @@
       }
     },
     {
+      "Sid": "OrganizationsAccess",
       "Effect": "Allow",
       "Action": "organizations:DescribeOrganization",
       "Resource": "*"
     },
     {
+      "Sid": "SSMReadAccess",
       "Effect": "Allow",
       "Action": [
         "ssm:CancelCommand",
@@ -136,6 +156,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "SSMComandAccess",
       "Effect": "Allow",
       "Action": "ssm:SendCommand",
       "Resource": [
@@ -144,31 +165,37 @@
       ]
     },
     {
+      "Sid": "FSXDescribeAccess",
       "Effect": "Allow",
       "Action": "fsx:DescribeBackups",
       "Resource": "arn:aws:fsx:*:*:backup/*"
     },
     {
+      "Sid": "FSxFileAccess",
       "Effect": "Allow",
       "Action": "fsx:DescribeFileSystems",
       "Resource": "arn:aws:fsx:*:*:file-system/*"
     },
     {
+      "Sid": "FSxVolumeAccess",
       "Effect": "Allow",
       "Action": "fsx:DescribeVolumes",
       "Resource": "arn:aws:fsx:*:*:volume/*/*"
     },
     {
+      "Sid": "FSxMachineAccess",
       "Effect": "Allow",
       "Action": "fsx:DescribeStorageVirtualMachines",
       "Resource": "arn:aws:fsx:*:*:storage-virtual-machine/*/*"
     },
     {
+      "Sid": "DirectoryServiceAccess",
       "Effect": "Allow",
       "Action": "ds:DescribeDirectories",
       "Resource": "*"
     },
     {
+      "Sid": "BackupGatewayListAccess",
       "Effect": "Allow",
       "Action": [
         "backup-gateway:ListGateways",
@@ -179,6 +206,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "BackupGatewayHypervisorAccess",
       "Effect": "Allow",
       "Action": [
         "backup-gateway:GetHypervisor",
@@ -187,6 +215,7 @@
       "Resource": "arn:aws:backup-gateway:*:*:hypervisor/*"
     },
     {
+      "Sid": "BackupGatewayMachineAccess",
       "Effect": "Allow",
       "Action": [
         "backup-gateway:GetVirtualMachine"
@@ -194,6 +223,7 @@
       "Resource": "arn:aws:backup-gateway:*:*:vm/*"
     },
     {
+      "Sid": "BackupGatewayAccess",
       "Effect": "Allow",
       "Action": [
         "backup-gateway:GetBandwidthRateLimitSchedule",
@@ -202,11 +232,13 @@
       "Resource": "arn:aws:backup-gateway:*:*:gateway/*"
     },
     {
+      "Sid": "CloudWatchAccess",
       "Effect": "Allow",
       "Action": "cloudwatch:GetMetricData",
       "Resource": "*"
     },
     {
+      "Sid": "TimestreamListAccess",
       "Effect": "Allow",
       "Action": [
         "timestream:ListDatabases",
@@ -217,6 +249,7 @@
       ]
     },
     {
+      "Sid": "TimestreamDescribeAccess",
       "Effect": "Allow",
       "Action": [
         "timestream:DescribeEndpoints"
@@ -224,6 +257,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "S3ListAccess",
       "Effect": "Allow",
       "Action": [
         "s3:ListAllMyBuckets"
@@ -231,6 +265,7 @@
       "Resource": "arn:aws:s3:::*"
     },
     {
+      "Sid": "RedshiftAccess",
       "Effect": "Allow",
       "Action": [
         "redshift:DescribeClusters",
@@ -246,6 +281,7 @@
       ]
     },
     {
+      "Sid": "RedshiftOptionsAccess",
       "Effect": "Allow",
       "Action": [
         "redshift:DescribeNodeConfigurationOptions",
@@ -256,6 +292,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "CloudFormationAccess",
       "Effect": "Allow",
       "Action": [
         "cloudformation:ListStacks"
@@ -265,6 +302,7 @@
       ]
     },
     {
+      "Sid": "SAPAccess",
       "Effect": "Allow",
       "Action": [
         "ssm-sap:GetOperation",
@@ -273,6 +311,7 @@
       "Resource": "*"
     },
     {
+      "Sid": "SAPDatabaseAccess",
       "Effect": "Allow",
       "Action": [
         "ssm-sap:GetDatabase",
@@ -281,6 +320,7 @@
       "Resource": "arn:aws:ssm-sap:*:*:*"
     },
     {
+      "Sid": "RAMAccess",
       "Effect": "Allow",
       "Action": [
         "ram:GetResourceShareAssociations"

--- a/docs/source/_static/managed-policies/AmazonConnectSynchronizationServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/AmazonConnectSynchronizationServiceRolePolicy.json
@@ -63,8 +63,18 @@
         "connect:ListPhoneNumbersV2",
         "connect:UpdatePhoneNumber",
         "connect:DescribePhoneNumber",
-        "connect:Associate*",
-        "connect:Disassociate*"
+        "connect:AssociatePhoneNumberContactFlow",
+        "connect:DisassociatePhoneNumberContactFlow",
+        "connect:AssociateRoutingProfileQueues",
+        "connect:DisassociateQueueQuickConnects",
+        "connect:AssociateQueueQuickConnects",
+        "connect:DisassociateUserProficiencies",
+        "connect:AssociateUserProficiencies",
+        "connect:DisassociateRoutingProfileQueues",
+        "connect:CreateAuthenticationProfile",
+        "connect:UpdateAuthenticationProfile",
+        "connect:DescribeAuthenticationProfile",
+        "connect:ListAuthenticationProfiles"
       ],
       "Resource": "*"
     },

--- a/docs/source/_static/managed-policies/AmazonSageMakerNotebooksServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/AmazonSageMakerNotebooksServiceRolePolicy.json
@@ -2,6 +2,14 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Sid": "AllowSageMakerDeleteApp",
+      "Effect": "Allow",
+      "Action": [
+        "sagemaker:DeleteApp"
+      ],
+      "Resource": "arn:aws:sagemaker:*:*:app/*"
+    },
+    {
       "Sid": "AllowEFSAccessPointCreation",
       "Effect": "Allow",
       "Action": "elasticfilesystem:CreateAccessPoint",


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced AWS policies with expanded permissions for services including AWS Backup, RDS, DynamoDB, EFS, and more.
	- Specific actions added to Amazon Connect policy for improved security and control.
	- New permission for deleting SageMaker applications introduced in the SageMaker policy.

- **Bug Fixes**
	- Replaced broad wildcard permissions in Amazon Connect with explicit actions to mitigate unintended access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->