### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSIncidentManagerServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/AWSIncidentManagerServiceRolePolicy.json
@@ -34,7 +34,10 @@
       "Resource": "*",
       "Condition": {
         "StringEquals": {
-          "cloudwatch:namespace": "AWS/IncidentManager"
+          "cloudwatch:namespace": [
+            "AWS/IncidentManager",
+            "AWS/Usage"
+          ]
         }
       }
     }


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated AWS Incident Manager Service Role policy to allow `cloudwatch:PutMetricData` action under two namespaces: `AWS/IncidentManager` and `AWS/Usage`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->