### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSDataSyncServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/AWSDataSyncServiceRolePolicy.json
@@ -21,6 +21,23 @@
       "Resource": [
         "arn:*:logs:*:*:log-group:/aws/datasync*:log-stream:*"
       ]
+    },
+    {
+      "Sid": "DataSyncSecretsManagerReadAccess",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:GetSecretValue"
+      ],
+      "Resource": [
+        "arn:*:secretsmanager:*:*:secret:aws-datasync!*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "secretsmanager:ResourceTag/aws:secretsmanager:owningService": "aws-datasync",
+          "aws:ResourceAccount": "${aws:PrincipalAccount}"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated managed policy documentation to reflect new permissions for AWS DataSync to read specific Secrets Manager secrets, with access restricted by resource tags and account matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->