### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSDataSyncFullAccess.json
+++ b/docs/source/_static/managed-policies/AWSDataSyncFullAccess.json
@@ -31,7 +31,10 @@
         "s3:ListBucket",
         "s3:ListBucketVersions",
         "s3-outposts:ListAccessPoints",
-        "s3-outposts:ListRegionalBuckets"
+        "s3-outposts:ListRegionalBuckets",
+        "secretsmanager:ListSecrets",
+        "kms:ListAliases",
+        "kms:DescribeKey"
       ],
       "Resource": "*"
     },

--- a/docs/source/_static/managed-policies/AWSQuickSetupManageJITNAResourcesExecutionPolicy.json
+++ b/docs/source/_static/managed-policies/AWSQuickSetupManageJITNAResourcesExecutionPolicy.json
@@ -48,7 +48,8 @@
       "Effect": "Allow",
       "Action": [
         "iam:CreateRole",
-        "iam:GetRole"
+        "iam:GetRole",
+        "iam:TagRole"
       ],
       "Resource": [
         "arn:aws:iam::*:role/SSM-JustInTimeAccessTokenRole"

--- a/docs/source/_static/managed-policies/AWSSystemsManagerJustInTimeNodeAccessRolePropagationPolicy.json
+++ b/docs/source/_static/managed-policies/AWSSystemsManagerJustInTimeNodeAccessRolePropagationPolicy.json
@@ -133,6 +133,22 @@
       }
     },
     {
+      "Sid": "RAMTaggingPermissions",
+      "Effect": "Allow",
+      "Action": "ram:TagResource",
+      "Resource": "arn:aws:ram:*:*:resource-share/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:RequestTag/SystemsManagerJustInTimeNodeAccessManaged": "true"
+        },
+        "ForAllValues:StringEquals": {
+          "aws:TagKeys": [
+            "SystemsManagerJustInTimeNodeAccessManaged"
+          ]
+        }
+      }
+    },
+    {
       "Sid": "RAMModificationPermissions",
       "Effect": "Allow",
       "Action": [

--- a/docs/source/_static/managed-policies/SageMakerStudioProjectProvisioningRolePolicy.json
+++ b/docs/source/_static/managed-policies/SageMakerStudioProjectProvisioningRolePolicy.json
@@ -682,7 +682,8 @@
       "Action": "iam:PassRole",
       "Resource": [
         "arn:aws:iam::*:role/datazone_usr_role_*",
-        "arn:aws:iam::*:role/SageMakerStudioQueryExecutionRole"
+        "arn:aws:iam::*:role/SageMakerStudioQueryExecutionRole",
+        "arn:aws:iam::*:role/service-role/AmazonSageMakerQueryExecution"
       ],
       "Condition": {
         "StringEquals": {
@@ -1249,7 +1250,10 @@
       "Action": [
         "iam:GetRole"
       ],
-      "Resource": "arn:aws:iam::*:role/SageMakerStudioQueryExecutionRole",
+      "Resource": [
+        "arn:aws:iam::*:role/SageMakerStudioQueryExecutionRole",
+        "arn:aws:iam::*:role/service-role/AmazonSageMakerQueryExecution"
+      ],
       "Effect": "Allow"
     },
     {
@@ -2755,6 +2759,25 @@
         },
         "ForAllValues:StringLike": {
           "aws:TagKeys": "AmazonDataZone*"
+        }
+      }
+    },
+    {
+      "Sid": "EventBridgeScheduleDeleteAction",
+      "Effect": "Allow",
+      "Action": [
+        "scheduler:DeleteSchedule"
+      ],
+      "Resource": [
+        "arn:aws:scheduler:*:*:schedule/SageMakerUnifiedStudio-*-*/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceAccount": "${aws:PrincipalAccount}",
+          "aws:CalledViaFirst": "cloudformation.amazonaws.com"
+        },
+        "Null": {
+          "aws:ResourceTag/AmazonDataZoneProject": "false"
         }
       }
     }


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded policy permissions to allow listing AWS Secrets Manager secrets and describing/listing AWS KMS keys and aliases.
	- Added permission to tag IAM roles in relevant managed policies.
	- Enabled tagging of AWS Resource Access Manager (RAM) resource shares under specific tag-based conditions.
	- Granted permission to delete certain EventBridge schedules, subject to specific conditions.
	- Extended IAM role permissions to include an additional SageMaker-related role for pass and get role actions.

- **Documentation**
	- Updated managed policy documents to reflect new and expanded permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->