### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSDataSyncFullAccess.json
+++ b/docs/source/_static/managed-policies/AWSDataSyncFullAccess.json
@@ -63,6 +63,25 @@
           "iam:AWSServiceName": "datasync.amazonaws.com"
         }
       }
+    },
+    {
+      "Sid": "DataSyncSecretsManagerWriteAccess",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:CreateSecret",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:DeleteSecret",
+        "secretsmanager:UpdateSecret"
+      ],
+      "Resource": [
+        "arn:*:secretsmanager:*:*:secret:aws-datasync!*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "secretsmanager:ResourceTag/aws:secretsmanager:owningService": "aws-datasync",
+          "aws:ResourceAccount": "${aws:PrincipalAccount}"
+        }
+      }
     }
   ]
 }

--- a/docs/source/_static/managed-policies/AWSMarketplaceFullAccess.json
+++ b/docs/source/_static/managed-policies/AWSMarketplaceFullAccess.json
@@ -57,24 +57,6 @@
     {
       "Effect": "Allow",
       "Action": [
-        "s3:ListBucket",
-        "s3:GetObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::*image-build*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "sns:Publish",
-        "sns:setTopicAttributes"
-      ],
-      "Resource": "arn:aws:sns:*:*:*image-build*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
         "iam:PassRole"
       ],
       "Resource": [
@@ -84,48 +66,6 @@
         "StringLike": {
           "iam:PassedToService": [
             "ec2.amazonaws.com"
-          ]
-        }
-      }
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ssm:StartAutomationExecution"
-      ],
-      "Resource": [
-        "arn:aws:ssm:eu-central-1:906690553262:automation-definition/*",
-        "arn:aws:ssm:us-east-1:058657716661:automation-definition/*",
-        "arn:aws:ssm:ap-northeast-1:340648487307:automation-definition/*",
-        "arn:aws:ssm:eu-west-1:564714592864:automation-definition/*",
-        "arn:aws:ssm:us-west-2:243045473901:automation-definition/*",
-        "arn:aws:ssm:ap-southeast-2:362149219987:automation-definition/*",
-        "arn:aws:ssm:eu-west-2:587945719687:automation-definition/*",
-        "arn:aws:ssm:us-east-2:134937423163:automation-definition/*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "iam:PassRole"
-      ],
-      "Resource": [
-        "*"
-      ],
-      "Condition": {
-        "StringLike": {
-          "iam:PassedToService": [
-            "ssm.amazonaws.com"
-          ],
-          "iam:AssociatedResourceARN": [
-            "arn:aws:ssm:eu-central-1:906690553262:automation-definition/*",
-            "arn:aws:ssm:us-east-1:058657716661:automation-definition/*",
-            "arn:aws:ssm:ap-northeast-1:340648487307:automation-definition/*",
-            "arn:aws:ssm:eu-west-1:564714592864:automation-definition/*",
-            "arn:aws:ssm:us-west-2:243045473901:automation-definition/*",
-            "arn:aws:ssm:ap-southeast-2:362149219987:automation-definition/*",
-            "arn:aws:ssm:eu-west-2:587945719687:automation-definition/*",
-            "arn:aws:ssm:us-east-2:134937423163:automation-definition/*"
           ]
         }
       }

--- a/docs/source/_static/managed-policies/AWSMarketplaceRead-only.json
+++ b/docs/source/_static/managed-policies/AWSMarketplaceRead-only.json
@@ -20,8 +20,6 @@
     {
       "Effect": "Allow",
       "Action": [
-        "aws-marketplace:ListBuilds",
-        "aws-marketplace:DescribeBuilds",
         "iam:ListRoles",
         "iam:ListInstanceProfiles",
         "sns:GetTopicAttributes",


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced DataSync permissions to allow management of specific AWS Secrets Manager secrets, with strict tagging and account ownership requirements.

- **Chores**
  - Removed certain S3, SNS, and SSM permissions from the AWS Marketplace Full Access policy.
  - Updated the AWS Marketplace Read-only policy by removing permissions for listing and describing builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->