### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AmazonEventBridgeApiDestinationsServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/AmazonEventBridgeApiDestinationsServiceRolePolicy.json
@@ -11,7 +11,12 @@
         "secretsmanager:GetSecretValue",
         "secretsmanager:PutSecretValue"
       ],
-      "Resource": "arn:aws:secretsmanager:*:*:secret:events!connection/*"
+      "Resource": "arn:aws:secretsmanager:*:*:secret:events!connection/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceAccount": "${aws:PrincipalAccount}"
+        }
+      }
     },
     {
       "Effect": "Allow",

--- a/docs/source/_static/managed-policies/IAMUserChangePassword.json
+++ b/docs/source/_static/managed-policies/IAMUserChangePassword.json
@@ -7,7 +7,8 @@
         "iam:ChangePassword"
       ],
       "Resource": [
-        "arn:aws:iam::*:user/${aws:username}"
+        "arn:aws:iam::*:user/${aws:username}",
+        "arn:aws:iam::*:user/*/${aws:username}"
       ]
     },
     {


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated policy documentation to restrict Secrets Manager permissions to secrets within the same AWS account.
  - Expanded IAM password change permissions to include users nested within path prefixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->