### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AmazonCloudWatchRUMReadOnlyAccess.json
+++ b/docs/source/_static/managed-policies/AmazonCloudWatchRUMReadOnlyAccess.json
@@ -9,7 +9,44 @@
         "rum:ListAppMonitors",
         "rum:ListRumMetricsDestinations",
         "rum:BatchGetRumMetricDefinitions",
-        "rum:GetResourcePolicy"
+        "rum:GetResourcePolicy",
+        "rum:ListTagsForResource"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "synthetics:describeCanariesLastRun",
+        "synthetics:describeCanaries"
+      ],
+      "Resource": "arn:aws:synthetics:*:*:canary:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:GetMetricData"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudwatch:DescribeAlarms"
+      ],
+      "Resource": "arn:aws:cloudwatch:*:*:alarm:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:DescribeLogGroups"
+      ],
+      "Resource": "arn:aws:logs:*:*:log-group::log-stream:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "xray:GetTraceSummaries"
       ],
       "Resource": "*"
     }

--- a/docs/source/_static/managed-policies/SageMakerStudioProjectUserRolePolicy.json
+++ b/docs/source/_static/managed-policies/SageMakerStudioProjectUserRolePolicy.json
@@ -661,22 +661,6 @@
       }
     },
     {
-      "Sid": "AirflowListDomainS3BucketPermissions",
-      "Effect": "Allow",
-      "Action": [
-        "s3:ListBucket"
-      ],
-      "Resource": "arn:aws:s3:::${aws:PrincipalTag/DomainBucketName}",
-      "Condition": {
-        "StringNotEquals": {
-          "aws:PrincipalTag/DomainBucketName": ""
-        },
-        "StringEquals": {
-          "aws:ResourceAccount": "${aws:PrincipalAccount}"
-        }
-      }
-    },
-    {
       "Sid": "ListDomainBucketFromAthenaFederatedCatalog",
       "Effect": "Allow",
       "Action": [
@@ -805,22 +789,6 @@
       "Resource": "*"
     },
     {
-      "Sid": "DataLakeEC2Permissions",
-      "Effect": "Allow",
-      "Action": [
-        "ec2:AuthorizeSecurityGroupEgress",
-        "ec2:AuthorizeSecurityGroupIngress",
-        "ec2:RevokeSecurityGroupEgress",
-        "ec2:RevokeSecurityGroupIngress"
-      ],
-      "Resource": "*",
-      "Condition": {
-        "StringEquals": {
-          "aws:ResourceTag/AmazonDataZoneProject": "${aws:PrincipalTag/AmazonDataZoneProject}"
-        }
-      }
-    },
-    {
       "Sid": "DataLakeAthenaPermissions",
       "Effect": "Allow",
       "Action": [
@@ -870,21 +838,6 @@
           "aws:ResourceTag/AmazonDataZoneProject": "${aws:PrincipalTag/AmazonDataZoneProject}"
         }
       }
-    },
-    {
-      "Sid": "DefaultAthenaDataCatalogPermissions",
-      "Effect": "Allow",
-      "Action": [
-        "athena:GetDatabase",
-        "athena:GetDataCatalog",
-        "athena:GetTableMetadata",
-        "athena:ListDatabases",
-        "athena:ListTableMetadata"
-      ],
-      "Resource": [
-        "arn:aws:athena:*:*:datacatalog/AwsDataCatalog",
-        "arn:aws:athena:*:*:datacatalog/awsdatacatalog"
-      ]
     },
     {
       "Sid": "AthenaListPermissions",
@@ -1475,7 +1428,6 @@
         "elasticmapreduce:ListInstanceFleets",
         "elasticmapreduce:ListInstanceGroups",
         "elasticmapreduce:ListBootstrapActions",
-        "elasticmapreduce:TerminateJobFlows",
         "elasticmapreduce:GetManagedScalingPolicy",
         "elasticmapreduce:GetOnClusterAppUIPresignedURL"
       ],
@@ -1947,7 +1899,8 @@
       "Effect": "Allow",
       "Action": [
         "bedrock:ListEvaluationJobs",
-        "bedrock:RetrieveAndGenerate"
+        "bedrock:RetrieveAndGenerate",
+        "bedrock:ListFoundationModels"
       ],
       "Resource": "*",
       "Condition": {


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated managed policy documentation for CloudWatch RUM ReadOnly Access to include additional read-only permissions for related AWS monitoring and diagnostics services.
  - Revised SageMaker Studio Project User Role policy documentation by removing certain permissions related to S3, EC2, and Athena, and updating permissions for EMR and Bedrock services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->