### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/Ec2InstanceConnectEndpoint.json
+++ b/docs/source/_static/managed-policies/Ec2InstanceConnectEndpoint.json
@@ -28,8 +28,10 @@
             "InstanceConnectEndpointId"
           ]
         },
-        "Null": {
-          "aws:RequestTag/InstanceConnectEndpointId": "false"
+        "StringLike": {
+          "aws:RequestTag/InstanceConnectEndpointId": [
+            "eice-*"
+          ]
         }
       }
     },
@@ -40,8 +42,10 @@
       ],
       "Resource": "arn:aws:ec2:*:*:network-interface/*",
       "Condition": {
-        "Null": {
-          "aws:ResourceTag/InstanceConnectEndpointId": "false"
+        "StringLike": {
+          "aws:ResourceTag/InstanceConnectEndpointId": [
+            "eice-*"
+          ]
         }
       }
     },
@@ -60,10 +64,32 @@
             "InstanceConnectEndpointId"
           ]
         },
-        "Null": {
-          "aws:RequestTag/InstanceConnectEndpointId": "false"
+        "StringLike": {
+          "aws:RequestTag/InstanceConnectEndpointId": [
+            "eice-*"
+          ]
         }
       }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AssignIpv6Addresses",
+        "ec2:UnassignIpv6Addresses"
+      ],
+      "Resource": "arn:aws:ec2:*:*:network-interface/*",
+      "Condition": {
+        "StringLike": {
+          "aws:ResourceTag/InstanceConnectEndpointId": [
+            "eice-*"
+          ]
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:ModifyNetworkInterfaceAttribute",
+      "Resource": "arn:aws:ec2:*:*:security-group/*"
     },
     {
       "Effect": "Allow",


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the managed policy to refine tag-based conditions for network interface actions.
  * Expanded allowed actions to include assigning and unassigning IPv6 addresses, and modifying network interface attributes related to security groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->