### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSSecurityIncidentResponseServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/AWSSecurityIncidentResponseServiceRolePolicy.json
@@ -6,9 +6,16 @@
       "Effect": "Allow",
       "Action": [
         "organizations:ListAccounts",
-        "organizations:ListChildren"
+        "organizations:ListChildren",
+        "organizations:DescribeAccount",
+        "organizations:ListDelegatedAdministrators"
       ],
-      "Resource": "*"
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceAccount": "${aws:PrincipalAccount}"
+        }
+      }
     },
     {
       "Sid": "SecurityIncidentResponseCreateCasePolicyTagOnCreate",

--- a/docs/source/_static/managed-policies/SageMakerStudioDomainExecutionRolePolicy.json
+++ b/docs/source/_static/managed-policies/SageMakerStudioDomainExecutionRolePolicy.json
@@ -246,6 +246,16 @@
         "datazone:ListProjectProfiles"
       ],
       "Resource": "arn:aws:datazone:*:*:domain/*"
+    },
+    {
+      "Sid": "AccountPoolPermissionsStatement",
+      "Effect": "Allow",
+      "Action": [
+        "datazone:GetAccountPool",
+        "datazone:ListAccountPools",
+        "datazone:ListAccountsInAccountPool"
+      ],
+      "Resource": "arn:aws:datazone:*:*:domain/*"
     }
   ]
 }


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added permissions for additional DataZone actions in the SageMaker Studio Domain Execution Role policy.
  * Expanded AWS Organizations permissions in the Security Incident Response policy, including new actions and a condition to restrict access to the principal account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->