### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSBillingReadOnlyAccess.json
+++ b/docs/source/_static/managed-policies/AWSBillingReadOnlyAccess.json
@@ -29,6 +29,8 @@
         "ce:ListCostAllocationTagBackfillHistory",
         "ce:GetTags",
         "ce:GetDimensionValues",
+        "ce:GetCostAndUsageComparisons",
+        "ce:GetCostComparisonDrivers",
         "consolidatedbilling:ListLinkedAccounts",
         "consolidatedbilling:GetAccountBillingRole",
         "cur:GetClassicReport",

--- a/docs/source/_static/managed-policies/AmazonSageMakerHyperPodObservabilityAdminAccess.json
+++ b/docs/source/_static/managed-policies/AmazonSageMakerHyperPodObservabilityAdminAccess.json
@@ -134,7 +134,7 @@
       "Action": [
         "iam:PassRole"
       ],
-      "Resource": "arn:aws:iam::*:role/AmazonSageMakerHyperPodObservabilityGrafanaAccess-*",
+      "Resource": "arn:aws:iam::*:role/service-role/AmazonSageMakerHyperPodObservabilityGrafanaAccess-*",
       "Condition": {
         "StringLike": {
           "iam:PassedToService": [
@@ -149,7 +149,7 @@
       "Action": [
         "iam:PassRole"
       ],
-      "Resource": "arn:aws:iam::*:role/AmazonSageMakerHyperPodObservabilityAddonAccess-*",
+      "Resource": "arn:aws:iam::*:role/service-role/AmazonSageMakerHyperPodObservabilityAddonAccess-*",
       "Condition": {
         "StringLike": {
           "iam:PassedToService": [
@@ -163,7 +163,7 @@
       "Effect": "Allow",
       "Action": "iam:GetRole",
       "Resource": [
-        "arn:aws:iam::*:role/AmazonSageMakerHyperPodObservabilityAddonAccess-*"
+        "arn:aws:iam::*:role/service-role/AmazonSageMakerHyperPodObservabilityAddonAccess-*"
       ]
     },
     {
@@ -195,10 +195,19 @@
       "Resource": "*"
     },
     {
-      "Sid": "EKSAddonDescribePodIdentityAccess",
+      "Sid": "EKSAddonPodIdentityAccess",
       "Effect": "Allow",
-      "Action": "eks:DescribePodIdentityAssociation",
-      "Resource": "arn:aws:eks:*:*:podidentityassociation/*/*"
+      "Action": [
+        "eks:DescribePodIdentityAssociation",
+        "eks:DeletePodIdentityAssociation",
+        "eks:UpdatePodIdentityAssociation"
+      ],
+      "Resource": "arn:aws:eks:*:*:podidentityassociation/*/*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/SageMaker": "true"
+        }
+      }
     },
     {
       "Sid": "EKSListDescribeAccess",


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated AWSBillingReadOnlyAccess to include Cost Explorer comparison actions (GetCostAndUsageComparisons, GetCostComparisonDrivers).
  - Revised AmazonSageMakerHyperPodObservabilityAdminAccess:
    - Switched IAM PassRole/GetRole resources to service-role ARNs for Grafana and Addon access.
    - Renamed EKS addon pod identity statement and expanded actions to Describe/Delete/Update.
    - Added a condition requiring the SageMaker resource tag for EKS pod identity operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->