### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSBackupServiceLinkedRolePolicyForBackup.json
+++ b/docs/source/_static/managed-policies/AWSBackupServiceLinkedRolePolicyForBackup.json
@@ -400,6 +400,21 @@
         "dsql:ListTagsForResource"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "OrgsListDelegatedAdmins",
+      "Effect": "Allow",
+      "Action": [
+        "organizations:ListDelegatedAdministrators"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "organizations:ServicePrincipal": [
+            "backup.amazonaws.com"
+          ]
+        }
+      }
     }
   ]
 }

--- a/docs/source/_static/managed-policies/ROSANodePoolManagementPolicy.json
+++ b/docs/source/_static/managed-policies/ROSANodePoolManagementPolicy.json
@@ -199,7 +199,8 @@
         "arn:aws:ec2:*:*:network-interface/*",
         "arn:aws:ec2:*:*:subnet/*",
         "arn:aws:ec2:*:*:security-group/*",
-        "arn:aws:ec2:*:*:volume/*"
+        "arn:aws:ec2:*:*:volume/*",
+        "arn:aws:ec2:*:*:capacity-reservation/*"
       ]
     },
     {


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - AWS Backup service-linked role now supports listing AWS Organizations delegated administrators when invoked by AWS Backup, improving cross-account administration visibility.
  - ROSA Node Pool Management policy now includes EC2 Capacity Reservations in instance launch permissions, enabling use of reserved capacity.
- Documentation
  - Updated managed policy documentation to reflect the new Organizations permission for AWS Backup.
  - Updated ROSA Node Pool Management policy docs to include the Capacity Reservation ARN in the supported resources list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->