### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSSSODirectoryAdministrator.json
+++ b/docs/source/_static/managed-policies/AWSSSODirectoryAdministrator.json
@@ -11,6 +11,20 @@
         "sso:ListDirectoryAssociations"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "AllowKMSKeyUseViaAWSIdentityStoreService",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": "identitystore.*.amazonaws.com",
+          "kms:EncryptionContext:aws:identitystore:identitystore-arn": "*"
+        }
+      }
     }
   ]
 }

--- a/docs/source/_static/managed-policies/AWSSSODirectoryReadOnly.json
+++ b/docs/source/_static/managed-policies/AWSSSODirectoryReadOnly.json
@@ -15,6 +15,20 @@
         "identitystore-auth:BatchGetSession"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "AllowKMSKeyUseViaAWSIdentityStoreService",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": "identitystore.*.amazonaws.com",
+          "kms:EncryptionContext:aws:identitystore:identitystore-arn": "*"
+        }
+      }
     }
   ]
 }

--- a/docs/source/_static/managed-policies/AWSSSOMasterAccountAdministrator.json
+++ b/docs/source/_static/managed-policies/AWSSSOMasterAccountAdministrator.json
@@ -76,6 +76,47 @@
       "Resource": [
         "arn:aws:identity-sync:*:*:profile/*"
       ]
+    },
+    {
+      "Sid": "AllowKMSKeyUseViaAWSIAMIdentityCenterService",
+      "Effect": "Allow",
+      "Action": [
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:Encrypt",
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": "sso.*.amazonaws.com",
+          "kms:EncryptionContext:aws:sso:instance-arn": "*"
+        }
+      }
+    },
+    {
+      "Sid": "AllowKMSKeyUseViaAWSIdentityStoreService",
+      "Effect": "Allow",
+      "Action": [
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:Encrypt",
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": "identitystore.*.amazonaws.com",
+          "kms:EncryptionContext:aws:identitystore:identitystore-arn": "*"
+        }
+      }
+    },
+    {
+      "Sid": "AllowKMSKeyDiscovery",
+      "Effect": "Allow",
+      "Action": [
+        "kms:ListAliases",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*"
     }
   ]
 }

--- a/docs/source/_static/managed-policies/AWSSSOMemberAccountAdministrator.json
+++ b/docs/source/_static/managed-policies/AWSSSOMemberAccountAdministrator.json
@@ -44,6 +44,47 @@
           "organizations:ServicePrincipal": "sso.amazonaws.com"
         }
       }
+    },
+    {
+      "Sid": "AllowKMSKeyUseViaAWSIAMIdentityCenterService",
+      "Effect": "Allow",
+      "Action": [
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:Encrypt",
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": "sso.*.amazonaws.com",
+          "kms:EncryptionContext:aws:sso:instance-arn": "*"
+        }
+      }
+    },
+    {
+      "Sid": "AllowKMSKeyUseViaAWSIdentityStoreService",
+      "Effect": "Allow",
+      "Action": [
+        "kms:GenerateDataKeyWithoutPlaintext",
+        "kms:Encrypt",
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": "identitystore.*.amazonaws.com",
+          "kms:EncryptionContext:aws:identitystore:identitystore-arn": "*"
+        }
+      }
+    },
+    {
+      "Sid": "AllowKMSKeyDiscovery",
+      "Effect": "Allow",
+      "Action": [
+        "kms:ListAliases",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*"
     }
   ]
 }

--- a/docs/source/_static/managed-policies/AWSSSOReadOnly.json
+++ b/docs/source/_static/managed-policies/AWSSSOReadOnly.json
@@ -26,6 +26,29 @@
         "signin:ListTrustedIdentityPropagationApplicationsForConsole"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "AllowKMSKeyUseViaAWSIAMIdentityCenterService",
+      "Effect": "Allow",
+      "Action": [
+        "kms:Decrypt"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "kms:ViaService": "sso.*.amazonaws.com",
+          "kms:EncryptionContext:aws:sso:instance-arn": "*"
+        }
+      }
+    },
+    {
+      "Sid": "AllowKMSKeyDiscovery",
+      "Effect": "Allow",
+      "Action": [
+        "kms:ListAliases",
+        "kms:DescribeKey"
+      ],
+      "Resource": "*"
     }
   ]
 }


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded SSO-related managed policies to allow KMS key usage via IAM Identity Center and Identity Store, with strict service and encryption context conditions.
  - Enabled KMS key discovery (ListAliases, DescribeKey) where applicable.
  - Read-only policies now support KMS decryption when invoked through approved services.

- Documentation
  - Updated managed policy documentation to reflect new KMS permissions and service-guarded conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->