### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/BedrockAgentCoreFullAccess.json
+++ b/docs/source/_static/managed-policies/BedrockAgentCoreFullAccess.json
@@ -219,6 +219,17 @@
       "Effect": "Allow",
       "Action": "iam:GetRole",
       "Resource": "arn:aws:iam::*:role/aws-service-role/application-signals.cloudwatch.amazonaws.com/AWSServiceRoleForCloudWatchApplicationSignals"
+    },
+    {
+      "Sid": "CreateBedrockAgentCoreNetworkServiceLinkedRolePermissions",
+      "Effect": "Allow",
+      "Action": "iam:CreateServiceLinkedRole",
+      "Resource": "arn:aws:iam::*:role/aws-service-role/network.bedrock-agentcore.amazonaws.com/AWSServiceRoleForBedrockAgentCoreNetwork",
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": "network.bedrock-agentcore.amazonaws.com"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated BedrockAgentCoreFullAccess managed policy documentation to include permission for creating the Bedrock Agent Core Network service-linked role.
  * Clarifies that this permission is restricted to the specific AWS service via a condition, improving guidance on required IAM permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->