### PR TITLE
Updates AWS managed policies

### DIFF
--- a/docs/source/_static/managed-policies/AWSCloud9Administrator.json
+++ b/docs/source/_static/managed-policies/AWSCloud9Administrator.json
@@ -50,6 +50,15 @@
       "Resource": [
         "arn:aws:ssm:*:*:document/*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssmmessages:OpenDataChannel"
+      ],
+      "Resource": [
+        "arn:aws:ssm:*:*:session/*"
+      ]
     }
   ]
 }

--- a/docs/source/_static/managed-policies/AWSCloud9EnvironmentMember.json
+++ b/docs/source/_static/managed-policies/AWSCloud9EnvironmentMember.json
@@ -51,6 +51,15 @@
       "Resource": [
         "arn:aws:ssm:*:*:document/*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssmmessages:OpenDataChannel"
+      ],
+      "Resource": [
+        "arn:aws:ssm:*:*:session/*"
+      ]
     }
   ]
 }

--- a/docs/source/_static/managed-policies/AWSCloud9User.json
+++ b/docs/source/_static/managed-policies/AWSCloud9User.json
@@ -92,6 +92,15 @@
       "Resource": [
         "arn:aws:ssm:*:*:document/*"
       ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssmmessages:OpenDataChannel"
+      ],
+      "Resource": [
+        "arn:aws:ssm:*:*:session/*"
+      ]
     }
   ]
 }

--- a/docs/source/_static/managed-policies/AWSSystemsManagerJustInTimeAccessTokenPolicy.json
+++ b/docs/source/_static/managed-policies/AWSSystemsManagerJustInTimeAccessTokenPolicy.json
@@ -14,11 +14,12 @@
       ]
     },
     {
-      "Sid": "TerminateAndResumeSession",
+      "Sid": "TerminateAndResumeSessionAndOpenDataChannel",
       "Effect": "Allow",
       "Action": [
         "ssm:TerminateSession",
-        "ssm:ResumeSession"
+        "ssm:ResumeSession",
+        "ssmmessages:OpenDataChannel"
       ],
       "Resource": "arn:aws:ssm:*:*:session/*"
     },

--- a/docs/source/_static/managed-policies/SecurityLakeResourceManagementServiceRolePolicy.json
+++ b/docs/source/_static/managed-policies/SecurityLakeResourceManagementServiceRolePolicy.json
@@ -80,7 +80,7 @@
         "StringEquals": {
           "aws:ResourceAccount": "${aws:PrincipalAccount}"
         },
-        "StringLike": {
+        "ArnLike": {
           "lambda:FunctionArn": "arn:aws:lambda:*:*:function:AmazonSecurityLakeMetastoreManager-*-*"
         }
       }


### PR DESCRIPTION
Updates AWS managed policies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded Cloud9 Administrator, Environment Member, and User managed policies to allow opening SSM Messages data channels for session resources.
  - Enhanced Systems Manager Just-In-Time Access policy to include opening data channels alongside terminating and resuming sessions.

- Documentation
  - Updated policy descriptions and statement IDs to reflect added permissions (e.g., SID rename to include OpenDataChannel).
  - Refined a Security Lake service role policy condition to use ARN-specific matching for Lambda functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->